### PR TITLE
ci: make test work in github actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,7 +35,7 @@ jobs:
         path: ~/.cargo/bin/circom
         # Since the version of circom is specified in `scripts/install-circom.sh`,
         # as long as the file doesn't change we can reuse the circom binary.
-        key: ${{ runner.os }}-circom-${{ hashFiles('./scripts/install-circom.sh') }}
+        key: ${{ runner.os }}-${{ matrix.node-version }}-circom-${{ hashFiles('./scripts/install-circom.sh') }}
     - name: Cache zkeyFiles
       id: cache-zkeyFiles
       uses: actions/cache@v3
@@ -43,7 +43,7 @@ jobs:
         path: ./zkeyFiles/rln
         # Since the version of rln-circuits is specified in `scripts/build-zkeys.sh`,
         # as long as the file doesn't change we can reuse the zkeyFiles.
-        key: ${{ runner.os }}-zkeyFiles-${{ hashFiles('./scripts/build-zkeys.sh') }}
+        key: ${{ runner.os }}-${{ matrix.node-version }}-zkeyFiles-${{ hashFiles('./scripts/build-zkeys.sh') }}
     - name: Build circuit params
       run: ./scripts/build-zkeys.sh
     - run: npm test

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,4 +28,22 @@ jobs:
         cache: 'npm'
     - run: npm ci
     - run: npm run build --if-present
+    - name: Cache circom
+      id: cache-circom
+      uses: actions/cache@v3
+      with:
+        path: ~/.cargo/bin/circom
+        # Since the version of circom is specified in `scripts/install-circom.sh`,
+        # as long as the file doesn't change we can reuse the circom binary.
+        key: ${{ runner.os }}-circom-${{ hashFiles('./scripts/install-circom.sh') }}
+    - name: Cache zkeyFiles
+      id: cache-zkeyFiles
+      uses: actions/cache@v3
+      with:
+        path: ./zkeyFiles/rln
+        # Since the version of rln-circuits is specified in `scripts/build-zkeys.sh`,
+        # as long as the file doesn't change we can reuse the zkeyFiles.
+        key: ${{ runner.os }}-zkeyFiles-${{ hashFiles('./scripts/build-zkeys.sh') }}
+    - name: Build circuit params
+      run: ./scripts/build-zkeys.sh
     - run: npm test

--- a/scripts/build-zkeys.sh
+++ b/scripts/build-zkeys.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+#
+# Clone rln-circuits and build params
+#
+
+default_rln_merkle_tree_depth=15
+rlnjs_merkle_tree_depth=20
+install_circom_script='./scripts/install-circom.sh'
+
+rln_circuits_version=86cbf5a
+rln_circuits_repo_url='https://github.com/Rate-Limiting-Nullifier/rln-circuits.git'
+rln_circuits_repo='rln-circuits'
+
+rln_circuits_relative_path='./circuits/rln.circom'
+rln_circuits_build_script='./scripts/build-circuits.sh'
+built_params_relative_path="$rln_circuits_repo/build/zkeyFiles"
+target_zkeyfiles_dir="./zkeyFiles/rln"
+target_rln_wasm_path="$target_zkeyfiles_dir/rln.wasm"
+target_rln_zkey_path="$target_zkeyfiles_dir/rln_final.zkey"
+target_rln_verifiation_key_path="$target_zkeyfiles_dir/verification_key.json"
+
+# Build params if any of them does not exist
+if [[ -f $target_rln_wasm_path ]] && [[ -f $target_rln_zkey_path ]] && [[ -f $target_rln_verifiation_key_path ]]; then
+    echo "All params exist. Don't build them"
+    exit 0;
+fi
+
+# Go to project root
+cd `dirname $0`/..
+
+# Make sure circom is installed
+bash $install_circom_script
+which circom && circom --version
+
+git clone $rln_circuits_repo_url $rln_circuits_repo
+# Go to circuits repo and the right version
+cd $rln_circuits_repo
+git checkout $rln_circuits_version
+# Change the default merkle tree depth of the circuit
+sed -i.bak "s/RLN(${default_rln_merkle_tree_depth})/RLN(${rlnjs_merkle_tree_depth})/" $rln_circuits_relative_path
+# Install the deps and the project
+npm install
+# Replace "snarkjs" with "npx snarkjs" to use the locally installed snarkjs
+sed -i.bak "s/^snarkjs /npx snarkjs /" "$rln_circuits_build_script"
+# Build circuits
+bash "${rln_circuits_build_script}" rln
+
+# Go back to rlnjs project root
+cd ..
+# Copy the built params to the zkeyFiles folder in rlnjs
+mkdir -p $target_zkeyfiles_dir
+cp $built_params_relative_path/* $target_zkeyfiles_dir
+ls -al $target_zkeyfiles_dir

--- a/scripts/build-zkeys.sh
+++ b/scripts/build-zkeys.sh
@@ -3,7 +3,6 @@
 # Clone rln-circuits and build params
 #
 
-default_rln_merkle_tree_depth=15
 rlnjs_merkle_tree_depth=20
 install_circom_script='./scripts/install-circom.sh'
 
@@ -37,7 +36,7 @@ git clone $rln_circuits_repo_url $rln_circuits_repo
 cd $rln_circuits_repo
 git checkout $rln_circuits_version
 # Change the default merkle tree depth of the circuit
-sed -i.bak "s/RLN(${default_rln_merkle_tree_depth})/RLN(${rlnjs_merkle_tree_depth})/" $rln_circuits_relative_path
+sed -i.bak "s/RLN([1-9][0-9]*)/RLN(${rlnjs_merkle_tree_depth})/" $rln_circuits_relative_path
 # Install the deps and the project
 npm install
 # Replace "snarkjs" with "npx snarkjs" to use the locally installed snarkjs

--- a/scripts/install-circom.sh
+++ b/scripts/install-circom.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+circom_version=v2.1.3
+
+if ! [ -x "$(command -v circom)" ]; then
+    git clone https://github.com/iden3/circom.git
+    cd circom
+    git checkout $circom_version
+    cargo build --release
+    cargo install --path circom
+fi


### PR DESCRIPTION
## What's wrong?
CI failed since zkeyFiles is not found when [testing](https://github.com/Rate-Limiting-Nullifier/rlnjs/actions/runs/4117410394/jobs/7108675590#step:6:29)

## How to fix it?
- Add `scripts/build-zkeys.sh`: clone rln-circuits, modify default merkle tree depth, and build params (zkeysFiles)
- Run the script in CI
- Cache `circom` binary and `zkeysFiles`, since it takes time to build them
  - Hash of the file `scripts/build-zkeys.sh` is used as the matching key of the cache for `circom` since the script contains `rln_circuits_version=86cbf5a`, the version of rln-circuits. Whenever we update the version, the cache is invalidated.
  - Same applied to `scripts/install-circom.sh`