### PR TITLE
Improve `package.json` to better handle browser and Node.js environments

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,11 +42,11 @@
     "access": "public"
   },
   "main": "./dist/index.node.js",
-  "types": "./dist/types/index.d.ts",
-  "exports": {
-    "import": "./dist/index.mjs",
-    "require": "./dist/index.node.js"
+  "module": "./dist/index.mjs",
+  "browser": {
+    "./dist/index.node.js": "./dist/index.mjs"
   },
+  "types": "./dist/types/index.d.ts",
   "directories": {
     "dist": "./dist",
     "src": "./src",

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -69,7 +69,7 @@ export default [
   // Node.js build
   {
     input,
-    output: { file: pkg.exports.require, format: 'cjs', banner },
+    output: { file: pkg.main, format: 'cjs', banner },
     external: Object.keys(pkg.dependencies),
     plugins: [
       cleaner({
@@ -84,7 +84,7 @@ export default [
   // Browser build
   {
     input,
-    output: { file: pkg.exports.import, format: 'es', banner },
+    output: { file: pkg.module, format: 'es', banner },
     plugins: [
       ...browserPlugins,
       visualizerPlugin,


### PR DESCRIPTION
## What's wrong?
It's reported that `Worker is not defined` happens when `next build`.

(I'm not that sure and it is just my understanding) next.js has server-side rendering, and the imported javascript is processed in NodeJS environment in `next build`. Our [previous settings](https://github.com/Rate-Limiting-Nullifier/rlnjs/blob/bda0f3e27296d433c818d643c3c574b0ba944edc/package.json#L46-L49) says "if you're code is in the es module format (using import), you get `index.mjs` when importing. If it's in cjs (using require), you get `index.node.js`".

So, since the next project is in ES module, `next build` imports `index.mjs`, which contains browser-specific API like `Worker`. And `next build` processes it in NodeJS where browser-specific API doesn't work, and thus we get `Worker is not defined`.

## How to fix it?
Make `index.node.js` the default file when importing, and replace it with `index.mjs` when the `browser` flag is given.

## Concerns
I tested in both NodeJS (with both ES Module and CommonJS) and browser (in ES Module) in my local laptop. There might be other cases where these settings lead to a wrong import behavior. We should add automatic tests to make sure the package can be imported correctly.