### PR TITLE
Support rln-diff in rln-circuits-v2

### DIFF
--- a/scripts/build-zkeys.sh
+++ b/scripts/build-zkeys.sh
@@ -2,34 +2,59 @@
 #
 # Clone rln-circuits and build params
 #
+# Usage:
+#   ./scripts/build-zkeys.sh <circuit_name>
+# Example:
+#   Build rln-same circuit
+#   $ ./scripts/build-zkeys.sh rln-same
+#   Build rln-diff circuit
+#   $ ./scripts/build-zkeys.sh rln-diff
+#   Build withdraw circuit
+#   $ ./scripts/build-zkeys.sh withdraw
+#   Build all circuits defined in `supported_circuit_names
+#   $ ./scripts/build-zkeys.sh
 
-install_circom_script='./scripts/install-circom.sh'
+#
+# Configs
+#
+supported_circuit_names=("rln-same" "rln-diff" "withdraw")
 
-rln_circuits_version=5577cba
-rln_circuits_repo_url='https://github.com/Rate-Limiting-Nullifier/rln-circuits-v2.git'
+rln_circuits_version=530bb5a
 rln_circuits_repo='rln-circuits-v2'
+rln_circuits_repo_url="https://github.com/Rate-Limiting-Nullifier/$rln_circuits_repo.git"
 
-rln_circuits_relative_path='./circuits/rln.circom'
-rln_circuits_build_script='./scripts/build-circuits.sh'
-built_params_relative_path="$rln_circuits_repo/build/zkeyFiles"
-target_zkeyfiles_dir="./zkeyFiles/rln-v2-same"
-target_rln_wasm_path="$target_zkeyfiles_dir/rln.wasm"
-target_rln_zkey_path="$target_zkeyfiles_dir/rln_final.zkey"
-target_rln_verifiation_key_path="$target_zkeyfiles_dir/verification_key.json"
+#
+# Determine which circuits to build
+#
 
-# Build params if any of them does not exist
-if [[ -f $target_rln_wasm_path ]] && [[ -f $target_rln_zkey_path ]] && [[ -f $target_rln_verifiation_key_path ]]; then
-    echo "All params exist. Don't build them"
-    exit 0;
+declare -a circuit_names_to_build
+
+circuit_name_arg=$1;
+
+# Check if the circuit name is supported
+for name in "${supported_circuit_names[@]}"
+do
+    if [ "$circuit_name_arg" == "$name" ]; then
+        circuit_names_to_build=($circuit_name_arg)
+        break
+    fi
+done
+# If circuit name
+if [ -z "$circuit_names_to_build" ] && [ -z "$circuit_name_arg" ]; then
+    circuit_names_to_build=("${supported_circuit_names[@]}")
 fi
 
-# Go to project root
+install_circom_script='./scripts/install-circom.sh'
+rln_circuits_build_script='./scripts/build-circuits.sh'
+
+# Go to project root of rlnjs
 cd `dirname $0`/..
 
 # Make sure circom is installed
 bash $install_circom_script
 which circom && circom --version
 
+# Clone rln_circuits_repo, checkout the right version, and install the deps
 git clone $rln_circuits_repo_url $rln_circuits_repo
 # Go to circuits repo and the right version
 cd $rln_circuits_repo
@@ -38,17 +63,51 @@ git checkout $rln_circuits_version
 npm install
 # Replace "snarkjs" with "npx snarkjs" to use the locally installed snarkjs
 sed -i.bak "s/^snarkjs /npx snarkjs /" "$rln_circuits_build_script"
-# Build circuits
-bash "${rln_circuits_build_script}" rln
 
-# Go back to rlnjs project root
-cd ..
-# Copy the built params to the zkeyFiles folder in rlnjs
-mkdir -p $target_zkeyfiles_dir
-# Copy params
-cp $built_params_relative_path/rln-same.wasm $target_rln_wasm_path
-cp $built_params_relative_path/rln_final.zkey $target_rln_zkey_path
-cp $built_params_relative_path/verification_key.json $target_rln_verifiation_key_path
-ls -al $target_zkeyfiles_dir
+build_and_copy_params() {
+    # We should already be in the rln-circuits-v2 project root
+    circuit_name=$1
+
+    # Return if the params already exist
+    # rlnjs
+    # |_rln-circuits-v2
+    # |_zkeyFiles
+    target_zkeyfiles_dir="../zkeyFiles/$circuit_name"
+    target_rln_wasm_path="$target_zkeyfiles_dir/circuit.wasm"
+    target_rln_zkey_path="$target_zkeyfiles_dir/final.zkey"
+    target_rln_verifiation_key_path="$target_zkeyfiles_dir/verification_key.json"
+    if [[ -f $target_rln_wasm_path ]] && [[ -f $target_rln_zkey_path ]] && [[ -f $target_rln_verifiation_key_path ]]; then
+        echo "All params exist. Don't build them"
+        return
+    fi
+
+    # Build the params
+    rln_circuits_build_script_args="";
+    if [[ $circuit_name == "rln-same" ]]; then
+        rln_circuits_build_script_args="same"
+    elif [[ $circuit_name == "rln-diff" ]]; then
+        rln_circuits_build_script_args="diff"
+    else
+        rln_circuits_build_script_args="withdraw"
+    fi
+    echo "Building circuit: $circuit_name"
+    bash "$rln_circuits_build_script" $rln_circuits_build_script_args
+
+    mkdir -p $target_zkeyfiles_dir
+    # Copy params from rln-circuits-v2/zkeyFiles/v2/<circuit_name> to rlnjs/zkeyFiles/<circuit_name>
+    built_params_relative_path="./zkeyFiles/v2/$circuit_name"
+
+    cp $built_params_relative_path/rln.wasm $target_rln_wasm_path
+    cp $built_params_relative_path/rln_final.zkey $target_rln_zkey_path
+    cp $built_params_relative_path/verification_key.json $target_rln_verifiation_key_path
+    ls -al $target_zkeyfiles_dir
+}
+
+for circuit_name in "${circuit_names_to_build[@]}"
+do
+    build_and_copy_params $circuit_name
+done
+
 # Remove the circuits repo
+cd ..
 rm -rf $rln_circuits_repo

--- a/scripts/build-zkeys.sh
+++ b/scripts/build-zkeys.sh
@@ -19,8 +19,8 @@
 #
 supported_circuit_names=("rln-same" "rln-diff" "withdraw")
 
-rln_circuits_version=530bb5a
-rln_circuits_repo='rln-circuits-v2'
+rln_circuits_version=10437bc
+rln_circuits_repo='circom-rln'
 rln_circuits_repo_url="https://github.com/Rate-Limiting-Nullifier/$rln_circuits_repo.git"
 
 #

--- a/scripts/install-circom.sh
+++ b/scripts/install-circom.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-circom_version=v2.1.4
+circom_version=v2.1.5
 
 if ! [ -x "$(command -v circom)" ]; then
     git clone https://github.com/iden3/circom.git

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,11 +13,14 @@ export {
 // Export RLN types
 export {
   StrBigInt,
-  RLNFullProof,
   Proof,
-  RLNPublicSignals,
-  RLNSNARKProof,
   VerificationKey,
-  RLNWitness,
   CircuitParamsFilePath,
 } from './types'
+
+export {
+  RLNFullProof,
+  RLNPublicSignals,
+  RLNSNARKProof,
+  RLNWitness,
+} from './rln'

--- a/src/rln-diff.ts
+++ b/src/rln-diff.ts
@@ -121,10 +121,10 @@ export default class RLNDiff {
   public async generateProof(signal: string, merkleProof: MerkleProof, messageId: number | bigint, epoch?: StrBigInt): Promise<RLNDiffFullProof> {
     // If epoch is not set, use unix epoch time rounded to 1 second
     const epochBigInt = epoch ? BigInt(epoch) : BigInt(Math.floor(Date.now() / 1000)) // rounded to nearest second
-    // Require messageId is in the range [1, messageLimit]
-    if (messageId <= 0 || messageId > this.messageLimit) {
+    // Require messageId is in the range [0, messageLimit - 1]
+    if (messageId < 0 || messageId >= this.messageLimit) {
       throw new Error(
-        'messageId must be in the range [1, messageLimit]: ' +
+        'messageId must be in the range [0, messageLimit - 1]: ' +
         `messageId=${messageId}, messageLimit=${this.messageLimit}`,
       )
     }

--- a/src/rln.ts
+++ b/src/rln.ts
@@ -122,10 +122,10 @@ export default class RLN {
   public async generateProof(signal: string, merkleProof: MerkleProof, messageId: number | bigint, epoch?: StrBigInt): Promise<RLNFullProof> {
     // If epoch is not set, use unix epoch time rounded to 1 second
     const epochBigInt = epoch ? BigInt(epoch) : BigInt(Math.floor(Date.now() / 1000)) // rounded to nearest second
-    // Require messageId is in the range [1, messageLimit]
-    if (messageId <= 0 || messageId > this.messageLimit) {
+    // Require messageId is in the range [0, messageLimit - 1]
+    if (messageId < 0 || messageId >= this.messageLimit) {
       throw new Error(
-        'messageId must be in the range [1, messageLimit]: ' +
+        'messageId must be in the range [0, messageLimit - 1]: ' +
         `messageId=${messageId}, messageLimit=${this.messageLimit}`,
       )
     }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,7 +1,7 @@
 export type StrBigInt = string | bigint
 
 /**
- * SNARK proof.
+ * snarkjs proof.
  */
 export type Proof = {
   pi_a: StrBigInt[]
@@ -11,38 +11,10 @@ export type Proof = {
   curve: string
 }
 
-/**
- * Public signals of the SNARK proof.
- */
-export type RLNPublicSignals = {
-  yShare: StrBigInt
-  merkleRoot: StrBigInt
-  internalNullifier: StrBigInt
-  x: StrBigInt
-  externalNullifier: StrBigInt
-  messageLimit: StrBigInt
-}
 
 /**
- * SNARK proof that contains both proof and public signals.
- * Can be verified directly by a SNARK verifier.
+ * snarkjs verification key.
  */
-export type RLNSNARKProof = {
-  proof: Proof
-  publicSignals: RLNPublicSignals
-}
-
-/**
- * RLN full proof that contains both SNARK proof and other information.
- * The proof is valid for a RLN user iff the epoch and rlnIdentifier match the user's
- * and the snarkProof is valid.
- */
-export type RLNFullProof = {
-  snarkProof: RLNSNARKProof
-  epoch: bigint
-  rlnIdentifier: bigint
-}
-
 export type VerificationKey = {
   protocol: string,
   curve: string,
@@ -55,17 +27,9 @@ export type VerificationKey = {
   IC: string[][],
 }
 
-export type RLNWitness = {
-  identitySecret: bigint,
-  messageId: bigint,
-  // Ignore `no-explicit-any` because the type of `identity_path_elements` in zk-kit is `any[]`
-  pathElements: any[], // eslint-disable-line @typescript-eslint/no-explicit-any
-  identityPathIndex: number[],
-  x: string | bigint,
-  externalNullifier: bigint,
-  messageLimit: bigint,
-}
-
+/**
+ * Path to the circuit parameters.
+ */
 export type CircuitParamsFilePath = {
   vkeyPath: string,
   wasmFilePath: string,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,5 @@
 import { ZqField } from 'ffjavascript'
-import { RLNFullProof, VerificationKey } from './types'
+import { VerificationKey } from './types'
 
 /*
   This is the "Baby Jubjub" curve described here:
@@ -36,41 +36,4 @@ export function parseVerificationKeyJSON(json: string): VerificationKey {
   if (!o.vk_alphabeta_12) throw new Error('Verification key has no vk_alphabeta_12')
   if (!o.IC) throw new Error('Verification key has no IC')
   return o
-}
-
-
-export function isProofSameExternalNullifier(proof1: RLNFullProof, proof2: RLNFullProof): boolean {
-  const publicSignals1 = proof1.snarkProof.publicSignals
-  const publicSignals2 = proof2.snarkProof.publicSignals
-  return (
-    proof1.epoch === proof2.epoch &&
-    proof1.rlnIdentifier === proof2.rlnIdentifier &&
-    BigInt(publicSignals1.externalNullifier) === BigInt(publicSignals2.externalNullifier)
-  )
-}
-
-/**
- * Checks if two RLN proofs are the same.
- * @param proof1 RLNFullProof 1
- * @param proof2 RLNFullProof 2
- * @returns
- */
-export function isSameProof(proof1: RLNFullProof, proof2: RLNFullProof): boolean {
-  // First compare the external nullifiers
-  if (!isProofSameExternalNullifier(proof1, proof2)) {
-    throw new Error('Proofs have different external nullifiers')
-  }
-  // Then, we compare the public inputs since the SNARK proof can be different for a
-  // same claim.
-  const publicSignals1 = proof1.snarkProof.publicSignals
-  const publicSignals2 = proof2.snarkProof.publicSignals
-  // We compare all public inputs but `merkleRoot` since it's possible that merkle root is changed
-  // (e.g. new leaf is inserted to the merkle tree) within the same epoch.
-  // NOTE: no need to check external nullifier here since it is already compared in
-  // `isProofSameExternalNullifier`
-  return (
-    BigInt(publicSignals1.yShare) === BigInt(publicSignals2.yShare) &&
-    BigInt(publicSignals1.internalNullifier) === BigInt(publicSignals2.internalNullifier) &&
-    BigInt(publicSignals1.x) === BigInt(publicSignals2.x)
-  )
 }

--- a/tests/configs.ts
+++ b/tests/configs.ts
@@ -13,7 +13,10 @@ function getParamsPath(paramsDir: string): CircuitParamsFilePath {
     }
 }
 
+const rlnSameParamsDirname = path.join(thisFileDirname, "..", "zkeyFiles", "rln-same");
+const rlnDiffParamsDirname = path.join(thisFileDirname, "..", "zkeyFiles", "rln-diff");
+const defaultParamsDirname = rlnSameParamsDirname;
 
-const defaultParamsDirname = path.join(thisFileDirname, "..", "zkeyFiles", "rln-same");
-
-export const defaultParamsPath = getParamsPath(defaultParamsDirname)
+export const rlnSameParamsPath = getParamsPath(defaultParamsDirname)
+export const rlnDiffParamsPath = getParamsPath(rlnDiffParamsDirname)
+export const defaultParamsPath = rlnSameParamsPath

--- a/tests/configs.ts
+++ b/tests/configs.ts
@@ -8,14 +8,12 @@ const thisFileDirname = __dirname
 function getParamsPath(paramsDir: string): CircuitParamsFilePath {
     return {
         vkeyPath: path.join(paramsDir, "verification_key.json"),
-        wasmFilePath: path.join(paramsDir, "rln.wasm"),
-        finalZkeyPath: path.join(paramsDir, "rln_final.zkey"),
+        wasmFilePath: path.join(paramsDir, "circuit.wasm"),
+        finalZkeyPath: path.join(paramsDir, "final.zkey"),
     }
 }
 
 
-const defaultParamsDirname = path.join(thisFileDirname, "..", "zkeyFiles", "rln-v2-same");
-const jsRLNParamsDirname = path.join(thisFileDirname, "..", "zkeyFiles", "js-rln");
+const defaultParamsDirname = path.join(thisFileDirname, "..", "zkeyFiles", "rln-same");
 
 export const defaultParamsPath = getParamsPath(defaultParamsDirname)
-export const jsRLNParamsPath = getParamsPath(jsRLNParamsDirname)

--- a/tests/factories.ts
+++ b/tests/factories.ts
@@ -2,11 +2,20 @@ import * as fs from "fs"
 import { RLN } from "../src"
 import { CircuitParamsFilePath } from "../src/types"
 import { Fq, parseVerificationKeyJSON } from "../src/utils"
-import { defaultParamsPath } from "./configs"
+import RLNDiff from "../src/rln-diff"
 
+export function rlnDiffInstanceFactory(
+    paramsPath: CircuitParamsFilePath,
+    rlnIdentifier?: bigint,
+    messageLimit?: bigint,
+    identity?: string,
+) {
+    const vKey = parseVerificationKeyJSON(fs.readFileSync(paramsPath.vkeyPath, "utf-8"))
+    return new RLNDiff(paramsPath.wasmFilePath, paramsPath.finalZkeyPath, vKey, rlnIdentifier, messageLimit, identity)
+}
 
 export function rlnInstanceFactory(
-    paramsPath: CircuitParamsFilePath = defaultParamsPath,
+    paramsPath: CircuitParamsFilePath,
     rlnIdentifier?: bigint,
     messageLimit?: bigint,
     identity?: string,

--- a/tests/rln-diff.test.ts
+++ b/tests/rln-diff.test.ts
@@ -1,0 +1,165 @@
+import { Identity } from '@semaphore-protocol/identity'
+import RLNDiff, { RLNDiffFullProof, DEFAULT_MESSAGE_LIMIT } from "../src/rln-diff"
+import Registry, { DEFAULT_REGISTRY_TREE_DEPTH } from '../src/registry'
+import { rlnDiffInstanceFactory, fieldFactory } from './factories'
+import { rlnDiffParamsPath } from "./configs";
+import poseidon from 'poseidon-lite';
+import { Fq } from '../src/utils';
+
+
+const defaultTreeDepth = DEFAULT_REGISTRY_TREE_DEPTH;
+
+jest.setTimeout(60000)
+
+// TODO: Add tests for RLN Identifier
+
+describe("RLNDiff", () => {
+  const identityCommitments: bigint[] = []
+  const paramsPath = rlnDiffParamsPath
+  const rlnInstance = rlnDiffInstanceFactory(paramsPath, undefined)
+  // Same parameter, same rln identifier, but different identity
+  const rlnInstance2 = rlnDiffInstanceFactory(paramsPath, rlnInstance.rlnIdentifier)
+
+  beforeAll(() => {
+    // Gen random identities
+    const numberOfLeaves = 3
+    for (let i = 0; i < numberOfLeaves; i += 1) {
+      const identity = new Identity()
+      const identityCommitment = identity.getCommitment()
+
+      identityCommitments.push(identityCommitment)
+    }
+  })
+
+  describe("RLNDiff functionalities", () => {
+    test("Should retrieve user secret using shamirRecovery", () => {
+      const signal1 = "hey hey"
+      const signalHash1 = RLNDiff.calculateSignalHash(signal1)
+      const signal2 = "hey hey again"
+      const signalHash2 = RLNDiff.calculateSignalHash(signal2)
+
+      const messageId = BigInt(1)
+      const epoch = fieldFactory()
+
+      function calculateY(
+        x: bigint,
+      ): bigint {
+        const externalNullifier = RLNDiff.calculateExternalNullifier(epoch, rlnInstance.rlnIdentifier)
+        const a1 = poseidon([rlnInstance.secretIdentity, externalNullifier, messageId])
+        // y = identitySecret + a1 * x
+        return Fq.normalize(rlnInstance.secretIdentity + a1 * x)
+      }
+
+      const y1 = calculateY(signalHash1)
+      const y2 = calculateY(signalHash2)
+
+      const retrievedSecret = RLNDiff.shamirRecovery(signalHash1, signalHash2, y1, y2)
+
+      expect(retrievedSecret).toEqual(rlnInstance.secretIdentity)
+    })
+
+    test("Should generate and verify RLN proof", async () => {
+      const leaves = Object.assign([], identityCommitments)
+      leaves.push(rlnInstance.commitment)
+
+      const signal = "hey hey"
+      const epoch = fieldFactory()
+      const merkleProof = Registry.generateMerkleProof(defaultTreeDepth, BigInt(0), leaves, rlnInstance.commitment)
+      // Test: succeeds with valid inputs
+      const messageId = BigInt(1)
+      // Sanity check that messageId is within range and thus valid
+      expect(messageId).toBeLessThanOrEqual(DEFAULT_MESSAGE_LIMIT)
+      const fullProof = await rlnInstance.generateProof(signal, merkleProof, messageId, epoch)
+      expect(await rlnInstance.verifyProof(fullProof)).toBe(true)
+
+      // Test: generateProof fails with invalid messageId
+      const invalidMessageIds = [0, DEFAULT_MESSAGE_LIMIT + 1]
+      for (const id of invalidMessageIds) {
+        expect(async () => {
+          await rlnInstance.generateProof(signal, merkleProof, id, epoch)
+        }).rejects.toThrowError("messageId must be in the range [1, messageLimit]")
+      }
+
+      const rlnInstanceAnother = rlnDiffInstanceFactory(paramsPath, rlnInstance.rlnIdentifier, BigInt(DEFAULT_MESSAGE_LIMIT))
+      // Test: proof from rlnInstance should be verifiable by rlnInstanceAnother since they
+      // use the same parameters (paramsPath, rlnIdentifier, and messageLimit)
+      expect(await rlnInstanceAnother.verifyProof(fullProof)).toBe(true)
+      // Test: rlnInstanceAnother should be able to verify the proof since users can have different rate limit
+      rlnInstanceAnother.messageLimit = BigInt(DEFAULT_MESSAGE_LIMIT + 1)
+      expect(await rlnInstanceAnother.verifyProof(fullProof)).toBe(true)
+    }, 30000)
+
+    test("Should retrieve user secret using full proofs", async () => {
+      const leaves = Object.assign([], identityCommitments)
+      leaves.push(rlnInstance.commitment)
+
+      const signal1 = "hey hey"
+      const signal2 = "hey hey hey"
+
+      const epoch1 = fieldFactory()
+      const epoch2 = fieldFactory([epoch1])
+      const merkleProof = Registry.generateMerkleProof(defaultTreeDepth, BigInt(0), leaves, rlnInstance.commitment)
+
+      leaves.push(rlnInstance2.commitment)
+      const merkleProof2 = Registry.generateMerkleProof(defaultTreeDepth, BigInt(0), leaves, rlnInstance2.commitment)
+
+      const messageId = 1
+      const proof = await rlnInstance.generateProof(signal1, merkleProof, messageId, epoch1)
+      // Test: another signal in the same epoch, messageId, and identity. Breached
+      const proofDiffSignal = await rlnInstance.generateProof(signal2, merkleProof, messageId, epoch1)
+      const retrievedSecret1 = RLNDiff.retrieveSecret(proof, proofDiffSignal)
+      expect(retrievedSecret1).toEqual(rlnInstance.secretIdentity)
+
+      // Test: messageId is different and thus there is no breach. retrieveSecret is expected to fail
+      const anotherMessageId = messageId + 1
+      const proofDiffMessageId = await rlnInstance.generateProof(signal1, merkleProof, anotherMessageId, epoch1)
+      expect(
+        () => RLNDiff.retrieveSecret(proof, proofDiffMessageId)
+      ).toThrow("Internal Nullifiers do not match! Cannot recover secret.")
+
+      // Test: epoch is different and there is no breach. retrieveSecret is expected to fail
+      const proofDiffEpoch = await rlnInstance.generateProof(signal1, merkleProof, messageId, epoch2)
+      expect(
+        () => RLNDiff.retrieveSecret(proof, proofDiffEpoch)
+      ).toThrow("External Nullifiers do not match! Cannot recover secret.")
+
+      // Test: inputs are the same as proof but it's from different identity.
+      // There is no breach and retrieveSecret is expected to fail
+      const proofDiffIdentity = await rlnInstance2.generateProof(signal1, merkleProof2, messageId, epoch1)
+      expect(
+        () => RLNDiff.retrieveSecret(proof, proofDiffIdentity)
+      ).toThrow("Internal Nullifiers do not match! Cannot recover secret.")
+
+      // Test: retrieveSecret fails with invalid public inputs
+      // 1. wrong epoch
+      const proofDiffPublicInputEpoch: RLNDiffFullProof = {
+        epoch: fieldFactory([proof.epoch]),
+        rlnIdentifier: proof.rlnIdentifier,
+        snarkProof: proof.snarkProof,
+      }
+      expect(
+        () => RLNDiff.retrieveSecret(proof, proofDiffPublicInputEpoch)
+      ).toThrow("External Nullifiers do not match! Cannot recover secret.")
+
+      // 2. wrong rln identifier
+      const proofDiffPublicInputRLNIdentifier: RLNDiffFullProof = {
+        epoch: proof.epoch,
+        rlnIdentifier: fieldFactory([proof.rlnIdentifier]),
+        snarkProof: proof.snarkProof,
+      }
+      expect(
+        () => RLNDiff.retrieveSecret(proof, proofDiffPublicInputRLNIdentifier)
+      ).toThrow("External Nullifiers do not match! Cannot recover secret.")
+    })
+
+    test("Should export/import to json", () => {
+      const rlnInstanceJson = rlnInstance.export();
+      const rlnInstanceFromJson = RLNDiff.import(rlnInstanceJson);
+      expect(rlnInstanceFromJson.identity.commitment).toEqual(rlnInstance.identity.commitment);
+      expect(rlnInstanceFromJson.rlnIdentifier).toEqual(rlnInstance.rlnIdentifier);
+      expect(rlnInstanceFromJson.wasmFilePath).toEqual(rlnInstance.wasmFilePath);
+      expect(rlnInstanceFromJson.finalZkeyPath).toEqual(rlnInstance.finalZkeyPath);
+      expect(rlnInstanceFromJson.verificationKey).toEqual(rlnInstance.verificationKey);
+    })
+  })
+})

--- a/tests/rln-diff.test.ts
+++ b/tests/rln-diff.test.ts
@@ -80,12 +80,10 @@ describe("RLNDiff", () => {
         }).rejects.toThrowError("messageId must be in the range [1, messageLimit]")
       }
 
-      const rlnInstanceAnother = rlnDiffInstanceFactory(paramsPath, rlnInstance.rlnIdentifier, BigInt(DEFAULT_MESSAGE_LIMIT))
-      // Test: proof from rlnInstance should be verifiable by rlnInstanceAnother since they
-      // use the same parameters (paramsPath, rlnIdentifier, and messageLimit)
-      expect(await rlnInstanceAnother.verifyProof(fullProof)).toBe(true)
-      // Test: rlnInstanceAnother should be able to verify the proof since users can have different rate limit
-      rlnInstanceAnother.messageLimit = BigInt(DEFAULT_MESSAGE_LIMIT + 1)
+      const messageLimitAnother = BigInt(DEFAULT_MESSAGE_LIMIT + 1)
+      const rlnInstanceAnother = rlnDiffInstanceFactory(paramsPath, rlnInstance.rlnIdentifier, messageLimitAnother)
+      // Test: proof from `rlnInstance` should still be verifiable by `rlnInstanceAnother` because `messageLimit`
+      // is a private input and thus the verifier cannot know the exact value
       expect(await rlnInstanceAnother.verifyProof(fullProof)).toBe(true)
     }, 30000)
 

--- a/tests/rln-diff.test.ts
+++ b/tests/rln-diff.test.ts
@@ -73,11 +73,11 @@ describe("RLNDiff", () => {
       expect(await rlnInstance.verifyProof(fullProof)).toBe(true)
 
       // Test: generateProof fails with invalid messageId
-      const invalidMessageIds = [0, DEFAULT_MESSAGE_LIMIT + 1]
+      const invalidMessageIds = [DEFAULT_MESSAGE_LIMIT, DEFAULT_MESSAGE_LIMIT + 1]
       for (const id of invalidMessageIds) {
         expect(async () => {
           await rlnInstance.generateProof(signal, merkleProof, id, epoch)
-        }).rejects.toThrowError("messageId must be in the range [1, messageLimit]")
+        }).rejects.toThrowError("messageId must be in the range")
       }
 
       const messageLimitAnother = BigInt(DEFAULT_MESSAGE_LIMIT + 1)

--- a/tests/rln-same.test.ts
+++ b/tests/rln-same.test.ts
@@ -156,13 +156,13 @@ describe("RLN", () => {
     })
 
     test("Should export/import to json", () => {
-      const rln_instance_json = rlnInstance.export();
-      const rln_instance_from_json = RLN.import(rln_instance_json);
-      expect(rln_instance_from_json.identity.commitment).toEqual(rlnInstance.identity.commitment);
-      expect(rln_instance_from_json.rlnIdentifier).toEqual(rlnInstance.rlnIdentifier);
-      expect(rln_instance_from_json.wasmFilePath).toEqual(rlnInstance.wasmFilePath);
-      expect(rln_instance_from_json.finalZkeyPath).toEqual(rlnInstance.finalZkeyPath);
-      expect(rln_instance_from_json.verificationKey).toEqual(rlnInstance.verificationKey);
+      const rlnInstanceJson = rlnInstance.export();
+      const rlnInstanceFromJson = RLN.import(rlnInstanceJson);
+      expect(rlnInstanceFromJson.identity.commitment).toEqual(rlnInstance.identity.commitment);
+      expect(rlnInstanceFromJson.rlnIdentifier).toEqual(rlnInstance.rlnIdentifier);
+      expect(rlnInstanceFromJson.wasmFilePath).toEqual(rlnInstance.wasmFilePath);
+      expect(rlnInstanceFromJson.finalZkeyPath).toEqual(rlnInstance.finalZkeyPath);
+      expect(rlnInstanceFromJson.verificationKey).toEqual(rlnInstance.verificationKey);
     })
   })
 })

--- a/tests/rln-same.test.ts
+++ b/tests/rln-same.test.ts
@@ -67,18 +67,18 @@ describe("RLN", () => {
       const epoch = fieldFactory()
       const merkleProof = Registry.generateMerkleProof(defaultTreeDepth, BigInt(0), leaves, rlnInstance.commitment)
       // Test: succeeds with valid inputs
-      const messageId = BigInt(1)
+      const messageId = BigInt(0)
       // Sanity check that messageId is within range and thus valid
       expect(messageId).toBeLessThanOrEqual(DEFAULT_MESSAGE_LIMIT)
       const fullProof = await rlnInstance.generateProof(signal, merkleProof, messageId, epoch)
       expect(await rlnInstance.verifyProof(fullProof)).toBe(true)
 
       // Test: generateProof fails with invalid messageId
-      const invalidMessageIds = [0, DEFAULT_MESSAGE_LIMIT + 1]
+      const invalidMessageIds = [DEFAULT_MESSAGE_LIMIT, DEFAULT_MESSAGE_LIMIT + 1]
       for (const id of invalidMessageIds) {
         expect(async () => {
           await rlnInstance.generateProof(signal, merkleProof, id, epoch)
-        }).rejects.toThrowError("messageId must be in the range [1, messageLimit]")
+        }).rejects.toThrowError("messageId must be in the range")
       }
 
       const rlnInstanceAnother = rlnInstanceFactory(paramsPath, rlnInstance.rlnIdentifier, BigInt(DEFAULT_MESSAGE_LIMIT))


### PR DESCRIPTION
Depends on #43 

## What's done?
1. Make `build-zkeys.sh` build params for `rln-same`, `rln-diff`, and `withdraw`
2. Add `rln-diff.ts`to support rln-diff circuit, while `rln.ts` supports rln-same and preserves its name `rln.ts`, to make it the default
3. Add tests for `rln-diff.ts`