### PR TITLE
Export circuit wrappers

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rlnjs",
-  "version": "3.1.1",
+  "version": "3.1.2",
   "description": "Client library for generating and using RLN ZK proofs.",
   "license": "MIT",
   "repository": "https://github.com/Rate-Limiting-Nullifier/rlnjs",

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,4 +6,4 @@ export { IMessageIDCounter } from './message-id-counter'
 
 export * from './types'
 
-export { RLNFullProof, RLNSNARKProof, RLNWitness, RLNPublicSignals } from './circuit-wrapper'
+export { RLNFullProof, RLNSNARKProof, RLNWitness, RLNPublicSignals, RLNProver, RLNVerifier, WithdrawProver } from './circuit-wrapper'


### PR DESCRIPTION
## What's done in the PR?
As discussed with @AtHeartEngineer offline, we should also export circuit wrappers like `RLNProver` and `RLNVerifier`, to allow users to prove without any other states