### PR TITLE
Check proof when create proof

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,7 +279,7 @@ const proofResult = await rln.verifyProof(epoch, message, proof) // true or fals
 
 A proof can be invalid in the following conditions:
 - The proof is not for you. You're using a different `rlnIdentifier`
-- The proof is not for the current epoch
+- The proof is not for the current epoch or message
 - The snark proof itself is invalid
 
 ### Saving a proof
@@ -287,10 +287,10 @@ User should save all proofs they receive to detect spams. You can save a proof b
 
 ```typescript
 const result = await rln.saveProof(proof)
-// status can be "added", "breach", or "invalid".
+// status can be "added", "seen", or "breach".
 // - "added" means the proof is successfully added to the cache
+// - "seen" means the proof is saved before
 // - "breach" means the added proof breaches the rate limit, the result will be `breach`, in which case the `secret` will be recovered and is accessible by accessing `result.secret`
-// - "invalid" means the proof is invalid, either it's received before or verification fails
 const status = result.status
 // if status is "breach", you can get the secret by
 const secret = result.secret

--- a/README.md
+++ b/README.md
@@ -278,8 +278,7 @@ const proofResult = await rln.verifyProof(epoch, message, proof) // true or fals
 ```
 
 A proof can be invalid in the following conditions:
-- The proof is not for you. You're using a different `rlnIdentifier`
-- The proof is not for the current epoch or message
+- Proof mismatches epoch, message, or rlnIdentifier
 - The snark proof itself is invalid
 
 ### Saving a proof

--- a/README.md
+++ b/README.md
@@ -286,10 +286,10 @@ User should save all proofs they receive to detect spams. You can save a proof b
 
 ```typescript
 const result = await rln.saveProof(proof)
-// status can be "added", "seen", or "breach".
-// - "added" means the proof is successfully added to the cache
-// - "seen" means the proof is saved before
-// - "breach" means the added proof breaches the rate limit, the result will be `breach`, in which case the `secret` will be recovered and is accessible by accessing `result.secret`
+// status can be VALID, DUPLICATE, BREACH.
+// - VALID means the proof is successfully added to the cache
+// - DUPLICATE means the proof is already saved before
+// - BREACH means the added proof breaches the rate limit, in which case the `secret` is recovered and is accessible by `result.secret`
 const status = result.status
 // if status is "breach", you can get the secret by
 const secret = result.secret

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -43,6 +43,12 @@ export type EvaluatedProof = {
 
 export interface ICache {
   addProof(proof: CachedProof): EvaluatedProof
+  /**
+   * Check the proof if it is either valid, seen, or breaching.
+   * Does not add the proof to the cache to avoid side effects.
+   * @param proof CachedProof
+   */
+  checkProof(proof: CachedProof): EvaluatedProof
 }
 
 const DEFAULT_CACHE_SIZE = 100
@@ -77,10 +83,28 @@ export class MemoryCache implements ICache {
     // Since `BigInt` can't be used as key, use String instead
     const epochString = String(proof.epoch)
     const nullifier = String(proof.nullifier)
+    // Check if the proof status
+    const resCheckProof = this.checkProof(proof)
+    // Only add the proof to the cache automatically if it's not seen before.
+    if (resCheckProof.status === Status.ADDED || resCheckProof.status === Status.BREACH) {
+      // Add proof to cache
+      this.cache[epochString][nullifier].push(proof)
+    }
+    return resCheckProof
+  }
 
-    this.evaluateEpoch(epochString)
+  /**
+   * Check the proof if it is either valid, seen, or breaching.
+   * Does not add the proof to the cache to avoid side effects.
+   * @param proof CachedProof
+   */
+  checkProof(proof: CachedProof): EvaluatedProof {
+    const epochString = String(proof.epoch)
+    const nullifier = String(proof.nullifier)
+    this.shiftEpochs(epochString)
     // If nullifier doesn't exist for this epoch, create an empty array
     this.cache[epochString][nullifier] = this.cache[epochString][nullifier] || []
+    const proofs = this.cache[epochString][nullifier]
 
     // Check if the proof already exists. It's O(n) but it's not a big deal since n is exactly the
     // rate limit and it's usually small.
@@ -92,33 +116,26 @@ export class MemoryCache implements ICache {
         BigInt(proof1.nullifier) === BigInt(proof2.nullifier)
       )
     }
-    const sameProofs = this.cache[epochString][nullifier].filter(p => isSameProof(p, proof))
-    if (sameProofs.length > 0) {
-      return { status: Status.SEEN, msg: 'Proof already exists' }
-    }
-
-    // Add proof to cache
-    this.cache[epochString][nullifier].push(proof)
-
-    // Check if there is more than 1 proof for this nullifier for this epoch
-    return this.evaluateNullifierAtEpoch(epochString, nullifier)
-  }
-
-  private evaluateNullifierAtEpoch(epoch: string, nullifier: string): EvaluatedProof {
-    const proofs = this.cache[epoch][nullifier]
-    if (proofs.length > 1) {
-      // If there is more than 1 proof, return breach and secret
-      const [x1, y1] = [BigInt(proofs[0].x), BigInt(proofs[0].y)]
-      const [x2, y2] = [BigInt(proofs[1].x), BigInt(proofs[1].y)]
-      const secret = shamirRecovery(x1, x2, y1, y2)
-      return { status: Status.BREACH, nullifier: nullifier, secret: secret, msg: 'Rate limit breach, secret attached' }
-    } else {
-      // If there is only 1 proof, return added
+    // OK
+    if (proofs.length === 0) {
       return { status: Status.ADDED, nullifier: nullifier, msg: 'Proof added to cache' }
+    // Exists proof with same epoch and nullifier. Possible breach or duplicate proof
+    } else {
+      const sameProofs = this.cache[epochString][nullifier].filter(p => isSameProof(p, proof))
+      if (sameProofs.length > 0) {
+        return { status: Status.SEEN, msg: 'Proof already exists' }
+      } else {
+        const otherProof = proofs[0]
+        // Breach. Return secret
+        const [x1, y1] = [BigInt(proof.x), BigInt(proof.y)]
+        const [x2, y2] = [BigInt(otherProof.x), BigInt(otherProof.y)]
+        const secret = shamirRecovery(x1, x2, y1, y2)
+        return { status: Status.BREACH, nullifier: nullifier, secret: secret, msg: 'Rate limit breach, secret attached' }
+      }
     }
   }
 
-  private evaluateEpoch(epoch: string) {
+  private shiftEpochs(epoch: string) {
     if (this.cache[epoch]) {
       // If epoch already exists, return
       return

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -31,7 +31,7 @@ type CacheMap = {
 export enum Status {
   ADDED = 'added',
   BREACH = 'breach',
-  INVALID = 'invalid',
+  SEEN = 'seen',
 }
 
 export type EvaluatedProof = {
@@ -94,7 +94,7 @@ export class MemoryCache implements ICache {
     }
     const sameProofs = this.cache[epochString][nullifier].filter(p => isSameProof(p, proof))
     if (sameProofs.length > 0) {
-      return { status: Status.INVALID, msg: 'Proof already exists' }
+      return { status: Status.SEEN, msg: 'Proof already exists' }
     }
 
     // Add proof to cache

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -57,7 +57,7 @@ export interface ICache {
   checkProof(proof: CachedProof): EvaluatedProof
 }
 
-const DEFAULT_CACHE_SIZE = 100
+export const DEFAULT_CACHE_SIZE = 100
 /**
  * Cache for storing proofs and automatically evaluating them for rate limit breaches
  * in the memory.

--- a/src/message-id-counter.ts
+++ b/src/message-id-counter.ts
@@ -1,7 +1,16 @@
+/**
+ * Always return **next** the current counter value and increment the counter.
+ * @param epoch epoch of the message
+ * @throws Error if the counter exceeds the message limit
+ */
 export interface IMessageIDCounter {
   messageLimit: bigint;
+  /**
+   * Return the current counter value and increment the counter.
+   *
+   * @param epoch
+   */
   getMessageIDAndIncrement(epoch: bigint): Promise<bigint>
-  peekNextMessageID(epoch: bigint): Promise<bigint>
 }
 
 type EpochMap = {
@@ -20,14 +29,6 @@ export class MemoryMessageIDCounter implements IMessageIDCounter {
 
   get messageLimit(): bigint {
     return this._messageLimit
-  }
-
-  async peekNextMessageID(epoch: bigint): Promise<bigint> {
-    const epochStr = epoch.toString()
-    if (this.epochToMessageID[epochStr] === undefined) {
-      return BigInt(0)
-    }
-    return this.epochToMessageID[epochStr]
   }
 
   async getMessageIDAndIncrement(epoch: bigint): Promise<bigint> {

--- a/tests/cache.test.ts
+++ b/tests/cache.test.ts
@@ -58,6 +58,9 @@ describe("MemoryCache", () => {
   test("should check proof 4", () => {
     const result4 = cache.addProof(proof4)
     expect(result4.status).toBe(Status.ADDED)
+    // two epochs are added to the cache now
+    expect(Object.keys(cache.cache).length
+    ).toBe(2)
   })
 
   test("should fail for proof 1 (duplicate proof)", () => {

--- a/tests/cache.test.ts
+++ b/tests/cache.test.ts
@@ -1,5 +1,5 @@
 import { MemoryCache } from "../src"
-import { CachedProof, Status } from '../src/cache'
+import { CachedProof, DEFAULT_CACHE_SIZE, Status } from '../src/cache'
 import { fieldFactory } from "./utils"
 
 describe("MemoryCache", () => {
@@ -32,32 +32,41 @@ describe("MemoryCache", () => {
   })
 
   test("should have a cache length of 100", () => {
-    expect(cache.cacheLength).toBe(100)
+    expect(cache.cacheLength).toBe(DEFAULT_CACHE_SIZE)
   })
 
   test("should successfully add proof", () => {
+    const resultCheckProof = cache.checkProof(proof1)
+    expect(resultCheckProof.status).toBe(Status.VALID)
     const result1 = cache.addProof(proof1)
-    expect(result1.status).toBe(Status.VALID)
+    expect(result1.status).toBe(resultCheckProof.status)
     expect(Object.keys(cache.cache).length
     ).toBe(1)
   })
 
   test("should detect breach and return secret", () => {
+    const resultCheckProof = cache.checkProof(proof2)
+    expect(resultCheckProof.status).toBe(Status.BREACH)
+    expect(resultCheckProof.secret).toBeGreaterThan(0)
     const result2 = cache.addProof(proof2)
-    expect(result2.status).toBe(Status.BREACH)
+    expect(result2.status).toBe(resultCheckProof.status)
     expect(result2.secret).toBeGreaterThan(0)
     expect(Object.keys(cache.cache).length
     ).toBe(1)
   })
 
   test("should check proof 3", () => {
+    const resultCheckProof = cache.checkProof(proof3)
+    expect(resultCheckProof.status).toBe(Status.VALID)
     const result3 = cache.addProof(proof3)
-    expect(result3.status).toBe(Status.VALID)
+    expect(result3.status).toBe(resultCheckProof.status)
   })
 
   test("should check proof 4", () => {
+    const resultCheckProof = cache.checkProof(proof4)
+    expect(resultCheckProof.status).toBe(Status.VALID)
     const result4 = cache.addProof(proof4)
-    expect(result4.status).toBe(Status.VALID)
+    expect(result4.status).toBe(resultCheckProof.status)
     // two epochs are added to the cache now
     expect(Object.keys(cache.cache).length
     ).toBe(2)
@@ -65,6 +74,8 @@ describe("MemoryCache", () => {
 
   test("should fail for proof 1 (duplicate proof)", () => {
     // Proof 1 is already in the cache
+    const resultCheckProof = cache.checkProof(proof1)
+    expect(resultCheckProof.status).toBe(Status.DUPLICATE)
     const result1 = cache.addProof(proof1)
     expect(result1.status).toBe(Status.DUPLICATE)
   });

--- a/tests/cache.test.ts
+++ b/tests/cache.test.ts
@@ -37,7 +37,7 @@ describe("MemoryCache", () => {
 
   test("should successfully add proof", () => {
     const result1 = cache.addProof(proof1)
-    expect(result1.status).toBe(Status.ADDED)
+    expect(result1.status).toBe(Status.VALID)
     expect(Object.keys(cache.cache).length
     ).toBe(1)
   })
@@ -52,12 +52,12 @@ describe("MemoryCache", () => {
 
   test("should check proof 3", () => {
     const result3 = cache.addProof(proof3)
-    expect(result3.status).toBe(Status.ADDED)
+    expect(result3.status).toBe(Status.VALID)
   })
 
   test("should check proof 4", () => {
     const result4 = cache.addProof(proof4)
-    expect(result4.status).toBe(Status.ADDED)
+    expect(result4.status).toBe(Status.VALID)
     // two epochs are added to the cache now
     expect(Object.keys(cache.cache).length
     ).toBe(2)
@@ -66,6 +66,6 @@ describe("MemoryCache", () => {
   test("should fail for proof 1 (duplicate proof)", () => {
     // Proof 1 is already in the cache
     const result1 = cache.addProof(proof1)
-    expect(result1.status).toBe(Status.SEEN)
+    expect(result1.status).toBe(Status.DUPLICATE)
   });
 })

--- a/tests/cache.test.ts
+++ b/tests/cache.test.ts
@@ -63,6 +63,6 @@ describe("MemoryCache", () => {
   test("should fail for proof 1 (duplicate proof)", () => {
     // Proof 1 is already in the cache
     const result1 = cache.addProof(proof1)
-    expect(result1.status).toBe(Status.INVALID)
+    expect(result1.status).toBe(Status.SEEN)
   });
 })

--- a/tests/circuit-wrapper.test.ts
+++ b/tests/circuit-wrapper.test.ts
@@ -21,7 +21,7 @@ describe("RLN", function () {
     const epoch = fieldFactory()
     const treeDepth = DEFAULT_REGISTRY_TREE_DEPTH
 
-    it("should generate valid proof", async function () {
+    test("should generate valid proof", async function () {
         const merkleProof = generateMerkleProof(rlnIdentifier, leaves, treeDepth, 0)
         const proof = await rlnProver.generateProof({
             rlnIdentifier,
@@ -40,7 +40,7 @@ describe("Withdraw", function () {
     const withdrawProver = new WithdrawProver(withdrawParams.wasmFilePath, withdrawParams.finalZkeyPath)
     const withdrawVerifier = new WithdrawVerifier(withdrawParams.verificationKey)
 
-    it("should generate valid proof", async function () {
+    test("should generate valid proof", async function () {
         const identitySecret = fieldFactory()
         const address = fieldFactory()
         const proof = await withdrawProver.generateProof({identitySecret, address})

--- a/tests/contract.test.ts
+++ b/tests/contract.test.ts
@@ -88,12 +88,12 @@ describe("RLNContract", () => {
         console.log("node killed")
     });
 
-    it("should be enough tokens in signer account", async () => {
+    test("should be enough tokens in signer account", async () => {
         expect(await erc20Contract.balanceOf(await signer.getAddress())).toBeGreaterThanOrEqual(expectedDepositAmount)
     });
 
     // RLNContract
-    it("should register", async () => {
+    test("should register", async () => {
         const balanceBefore = await erc20Contract.balanceOf(await signer.getAddress())
         await rlnContractWrapper.register(identityCommitment, expectedMessageLimit)
         const balanceAfter = await erc20Contract.balanceOf(await signer.getAddress())
@@ -104,7 +104,7 @@ describe("RLNContract", () => {
         expect(balanceBefore - balanceAfter).toBe(expectedDepositAmount)
     });
 
-    it("should withdraw and release", async () => {
+    test("should withdraw and release", async () => {
         // Test: after calling withdraw, user should not receive tokens until calling release
         const balanceBefore = await erc20Contract.balanceOf(await signer.getAddress())
         await rlnContractWrapper.withdraw(identityCommitment, mockProof)
@@ -125,7 +125,7 @@ describe("RLNContract", () => {
         expect(balanceAfterRelease - balanceBeforeRelease).toBe(expectedDepositAmount)
     });
 
-    it("should register another and slash with proof", async () => {
+    test("should register another and slash with proof", async () => {
         // Test: should register
         await rlnContractWrapperAnother.register(identityCommitmentAnother, expectedMessageLimit)
         const user = await rlnContractWrapperAnother.getUser(identityCommitmentAnother)
@@ -143,7 +143,7 @@ describe("RLNContract", () => {
         expect(balanceAfter - balanceBefore).toBe(expectedReceivedAmount)
     });
 
-    it("should get logs", async () => {
+    test("should get logs", async () => {
         const logs = await rlnContractWrapper.getLogs()
         expect(logs.length).toBe(4)
         expect(logs[0].name).toBe("MemberRegistered")

--- a/tests/field-artithmetics.test.ts
+++ b/tests/field-artithmetics.test.ts
@@ -2,7 +2,7 @@ import { Fq } from "../src/common"
 
 describe("Field arithmetics", () => {
   describe("Test bunch of calculations in Fq", () => {
-    it("Retrieve n from y = kx + n", () => {
+    test("Retrieve n from y = kx + n", () => {
       const k = Fq.random()
       const n = Fq.random()
 
@@ -21,7 +21,7 @@ describe("Field arithmetics", () => {
       expect(retrieved).toEqual(n)
     })
 
-    it("Lagrange in Fq", () => {
+    test("Lagrange in Fq", () => {
       const degree = 4
 
       const coeffs: Array<bigint> = [BigInt(7), BigInt(6), BigInt(9), BigInt(1), BigInt(7)]

--- a/tests/message-id-counter.test.ts
+++ b/tests/message-id-counter.test.ts
@@ -1,15 +1,8 @@
-// export interface IMessageIDCounter {
-//     messageLimit: bigint;
-//     getMessageIDAndIncrement(epoch: bigint): Promise<bigint>
-//     peekNextMessageID(epoch: bigint): Promise<bigint>
-//   }
-
-import { MemoryMessageIDCounter } from "../src/message-id-counter";
-
+import { FakeMessageIDCounter } from "./utils";
 
 describe('MessageIDCounter', () => {
     const messageLimit = BigInt(1)
-    const messageIDCounter = new MemoryMessageIDCounter(messageLimit)
+    const messageIDCounter = new FakeMessageIDCounter(messageLimit)
 
     it('should return correct message limit', async () => {
         expect(messageIDCounter.messageLimit).toEqual(messageLimit)

--- a/tests/message-id-counter.test.ts
+++ b/tests/message-id-counter.test.ts
@@ -4,11 +4,11 @@ describe('MessageIDCounter', () => {
     const messageLimit = BigInt(1)
     const messageIDCounter = new FakeMessageIDCounter(messageLimit)
 
-    it('should return correct message limit', async () => {
+    test('should return correct message limit', async () => {
         expect(messageIDCounter.messageLimit).toEqual(messageLimit)
     });
 
-    it('should return correct message ID', async () => {
+    test('should return correct message ID', async () => {
         const epoch0 = BigInt(0)
         const epoch1 = BigInt(1)
         const epoch2 = BigInt(2)

--- a/tests/rln-registry.test.ts
+++ b/tests/rln-registry.test.ts
@@ -29,11 +29,11 @@ describe('MemoryRLNRegistry', () => {
       registry = new MemoryRLNRegistry(rlnIdentifier, treeDepth);
   });
 
-  it('should be initialized correctly', async () => {
+  test('should be initialized correctly', async () => {
     expect(await registry.getAllRateCommitments()).toEqual([])
   });
 
-  it('should fail when we query `identityCommitment0` before registration', async () => {
+  test('should fail when we query `identityCommitment0` before registration', async () => {
     expect(await registry.isRegistered(identityCommitment0)).toBeFalsy()
     await expect(async () => {
       await registry.getMessageLimit(identityCommitment0)
@@ -46,7 +46,7 @@ describe('MemoryRLNRegistry', () => {
     }).rejects.toThrow()
   });
 
-  it('should register with `messageLimit`', async () => {
+  test('should register with `messageLimit`', async () => {
     await registry.register(identityCommitment0, messageLimit0)
     expect(await registry.isRegistered(identityCommitment0)).toBeTruthy()
     expect(await registry.getMessageLimit(identityCommitment0)).toEqual(messageLimit0)
@@ -54,7 +54,7 @@ describe('MemoryRLNRegistry', () => {
     expect(await registry.getRateCommitment(identityCommitment0)).toEqual(expectedRateCommitment)
   });
 
-  it('should fail to register `identityCommitment0` again', async () => {
+  test('should fail to register `identityCommitment0` again', async () => {
     await expect(async () => {
       await registry.register(identityCommitment0, messageLimit0)
     }).rejects.toThrow()
@@ -64,7 +64,7 @@ describe('MemoryRLNRegistry', () => {
     }).rejects.toThrow()
   });
 
-  it('should register `identityCommitment1`', async () => {
+  test('should register `identityCommitment1`', async () => {
     await registry.register(identityCommitment1, messageLimit1)
     expect(await registry.isRegistered(identityCommitment1)).toBeTruthy()
     expect(await registry.getMessageLimit(identityCommitment1)).toEqual(messageLimit1)
@@ -72,7 +72,7 @@ describe('MemoryRLNRegistry', () => {
     expect(await registry.getRateCommitment(identityCommitment1)).toEqual(expectedRateCommitment)
   });
 
-  it('should delete `identityCommitment0`', async () => {
+  test('should delete `identityCommitment0`', async () => {
     await registry.withdraw(identitySecret0)
     await registry.releaseWithdrawal(identityCommitment0)
     expect(await registry.isRegistered(identityCommitment0)).toBeFalsy()
@@ -84,17 +84,17 @@ describe('MemoryRLNRegistry', () => {
     }).rejects.toThrow()
   });
 
-  it('should fail to delete `identityCommitment0` again', async () => {
+  test('should fail to delete `identityCommitment0` again', async () => {
     await expect(async () => {
       await registry.withdraw(identitySecret0)
     }).rejects.toThrow()
   });
 
-  it('should return correct final states', async () => {
+  test('should return correct final states', async () => {
     expect((await registry.getAllRateCommitments()).length).toEqual(2)
   });
 
-  it('should generate valid merkle proof for `identityCommitment1`', async () => {
+  test('should generate valid merkle proof for `identityCommitment1`', async () => {
     const proof = await registry.generateMerkleProof(identityCommitment1)
     expect(proof.root).toEqual(await registry.getMerkleRoot())
 
@@ -166,11 +166,11 @@ describe('ContractRLNRegistry', () => {
     console.log("node killed")
   });
 
-  it('should be initialized correctly', async () => {
+  test('should be initialized correctly', async () => {
     expect(await registry.getAllRateCommitments()).toEqual([])
   });
 
-  it('should fail when we query `identityCommitment0` before registration', async () => {
+  test('should fail when we query `identityCommitment0` before registration', async () => {
     expect(await registry.isRegistered(identityCommitment0)).toBeFalsy()
     await expect(async () => {
       await registry.getMessageLimit(identityCommitment0)
@@ -183,7 +183,7 @@ describe('ContractRLNRegistry', () => {
     }).rejects.toThrow()
   });
 
-  it('should register with `messageLimit`', async () => {
+  test('should register with `messageLimit`', async () => {
     await registry.register(identityCommitment0, messageLimit0)
     expect(await registry.isRegistered(identityCommitment0)).toBeTruthy()
     expect(await registry.getMessageLimit(identityCommitment0)).toEqual(messageLimit0)
@@ -191,7 +191,7 @@ describe('ContractRLNRegistry', () => {
     expect(await registry.getRateCommitment(identityCommitment0)).toEqual(expectedRateCommitment)
   });
 
-  it('should fail to register `identityCommitment0` again', async () => {
+  test('should fail to register `identityCommitment0` again', async () => {
     await expect(async () => {
       await registry.register(identityCommitment0, messageLimit0)
     }).rejects.toThrow()
@@ -201,7 +201,7 @@ describe('ContractRLNRegistry', () => {
     }).rejects.toThrow()
   });
 
-  it('should register `identityCommitment1`', async () => {
+  test('should register `identityCommitment1`', async () => {
     await registry.register(identityCommitment1, messageLimit1)
     expect(await registry.isRegistered(identityCommitment1)).toBeTruthy()
     expect(await registry.getMessageLimit(identityCommitment1)).toEqual(messageLimit1)
@@ -209,7 +209,7 @@ describe('ContractRLNRegistry', () => {
     expect(await registry.getRateCommitment(identityCommitment1)).toEqual(expectedRateCommitment)
   });
 
-  it('should delete `identityCommitment0`', async () => {
+  test('should delete `identityCommitment0`', async () => {
     await registry.withdraw(identitySecret0)
     await waitUntilFreezePeriodPassed()
     await registry.releaseWithdrawal(identityCommitment0)
@@ -222,17 +222,17 @@ describe('ContractRLNRegistry', () => {
     }).rejects.toThrow()
   });
 
-  it('should fail to delete `identityCommitment0` again', async () => {
+  test('should fail to delete `identityCommitment0` again', async () => {
     await expect(async () => {
       await registry.withdraw(identitySecret0)
     }).rejects.toThrow()
   });
 
-  it('should return correct final states', async () => {
+  test('should return correct final states', async () => {
     expect((await registry.getAllRateCommitments()).length).toEqual(2)
   });
 
-  it('should generate valid merkle proof for `identityCommitment1`', async () => {
+  test('should generate valid merkle proof for `identityCommitment1`', async () => {
     const proof = await registry.generateMerkleProof(identityCommitment1)
     expect(proof.root).toEqual(await registry.getMerkleRoot())
 

--- a/tests/rln.test.ts
+++ b/tests/rln.test.ts
@@ -286,9 +286,9 @@ describe("RLN", function () {
             // messageLimitA1 is 1, so A1 can only create 1 proof per epoch
             // Test: can save the first proof
             proofA10 = await rlnA1.createProof(epoch0, message0);
-            // Test: status should be 'seen' when saving duplicate proof since it has been saved in createProof
+            // Test: status should be DUPLICATE when saving duplicate proof since it has been saved in createProof
             const resA10Again = await rlnA1.saveProof(proofA10);
-            expect(resA10Again.status).toBe(Status.SEEN);
+            expect(resA10Again.status).toBe(Status.DUPLICATE);
 
             // Reset messageIDCounterA1 at epoch0 to bypass the message id counter and
             // let it create a proof when it already exceeds `messageLimitA1`.
@@ -326,7 +326,7 @@ describe("RLN", function () {
             // Test: A0 is up-to-date and receives more than `messageLimitA1` proofs,
             // so A1's secret is breached by A0
             const resA10 = await rlnA0.saveProof(proofA10);
-            expect(resA10.status).toBe(Status.ADDED);
+            expect(resA10.status).toBe(Status.VALID);
             const resA12 = await rlnA0.saveProof(proofA11);
             expect(resA12.status).toBe(Status.BREACH);
             if (resA12.secret === undefined) {

--- a/tests/rln.test.ts
+++ b/tests/rln.test.ts
@@ -12,7 +12,7 @@ describe("RLN", function () {
         const rlnIdentifierA = BigInt(1);
         const registry = new MemoryRLNRegistry(rlnIdentifierA, 20)
 
-        it("should fail when neither proving params nor verification key is given", async function () {
+        test("should fail when neither proving params nor verification key is given", async function () {
             expect(() => {
                 new RLN({
                     rlnIdentifier: rlnIdentifierA,
@@ -24,7 +24,7 @@ describe("RLN", function () {
             );
         });
 
-        it("should fail to prove if no proving params is given as constructor arguments", async function () {
+        test("should fail to prove if no proving params is given as constructor arguments", async function () {
             const rln = new RLN({
                 rlnIdentifier: rlnIdentifierA,
                 registry,
@@ -35,7 +35,7 @@ describe("RLN", function () {
             }).rejects.toThrow("Prover is not initialized");
         });
 
-        it("should fail when verifying if no verification key is given as constructor arguments", async function () {
+        test("should fail when verifying if no verification key is given as constructor arguments", async function () {
             const rln = new RLN({
                 rlnIdentifier: rlnIdentifierA,
                 registry,
@@ -56,7 +56,7 @@ describe("RLN", function () {
         const fakeProvider = {} as ethers.Provider
         const fakeContractAddress = "0x0000000000000000000000000000000000005678"
 
-        it("should fail when neither proving params nor verification key is given", async function () {
+        test("should fail when neither proving params nor verification key is given", async function () {
             expect(() => {
                 RLN.createWithContractRegistry({
                     rlnIdentifier: rlnIdentifierA,
@@ -69,7 +69,7 @@ describe("RLN", function () {
             );
         });
 
-        it("should fail to prove if no proving params is given as constructor arguments", async function () {
+        test("should fail to prove if no proving params is given as constructor arguments", async function () {
             const rln = RLN.createWithContractRegistry({
                 rlnIdentifier: rlnIdentifierA,
                 provider: fakeProvider,
@@ -81,7 +81,7 @@ describe("RLN", function () {
             }).rejects.toThrow("Prover is not initialized");
         });
 
-        it("should fail when verifying if no verification key is given as constructor arguments", async function () {
+        test("should fail when verifying if no verification key is given as constructor arguments", async function () {
             const rln = RLN.createWithContractRegistry({
                 rlnIdentifier: rlnIdentifierA,
                 provider: fakeProvider,
@@ -187,19 +187,19 @@ describe("RLN", function () {
             console.log("node killed")
         });
 
-        it("should have correct members after initialization", async function () {
+        test("should have correct members after initialization", async function () {
             expect(await rlnA0.isRegistered()).toBe(false);
             expect((await rlnA0.getAllRateCommitments()).length).toBe(0);
             expect(await rlnA0.getMerkleRoot()).toBe(await rlnA1.getMerkleRoot());
         });
 
-        it("should fail when creating proof if not registered", async function () {
+        test("should fail when creating proof if not registered", async function () {
             await expect(async () => {
                 await rlnA0.createProof(BigInt(0), "abc")
             }).rejects.toThrow("User has not registered before");
         });
 
-        it("should register A0 successfully", async function () {
+        test("should register A0 successfully", async function () {
             await rlnA0.register(messageLimitA0, messageIDCounterA0);
             // A0 has not been updated in the registry
             expect(await rlnA0.isRegistered()).toBe(true);
@@ -208,7 +208,7 @@ describe("RLN", function () {
             expect(allRateCommitments[0]).toBe(await rlnA0.getRateCommitment());
         });
 
-        it("should be able to set message id counter", async function () {
+        test("should be able to set message id counter", async function () {
             // Test: set a new message id counter with zero message limit
             // I.e. no message can be sent
             const zeroMessageLimit = BigInt(0)
@@ -221,7 +221,7 @@ describe("RLN", function () {
             await rlnA0.setMessageIDCounter(messageIDCounterA0)
         })
 
-        it("should be able to create proof", async function () {
+        test("should be able to create proof", async function () {
             const messageIDBefore = await messageIDCounterA0.peekNextMessageID(epoch0);
             proofA00 = await rlnA0.createProof(epoch0, message0);
             const messageIDAfter = await messageIDCounterA0.peekNextMessageID(epoch0);
@@ -229,7 +229,7 @@ describe("RLN", function () {
             expect(await rlnA0.verifyProof(epoch0, message0, proofA00)).toBe(true);
         });
 
-        it("should fail to create proof if messageID exceeds limit", async function () {
+        test("should fail to create proof if messageID exceeds limit", async function () {
             const currentMessageID = await messageIDCounterA0.peekNextMessageID(epoch0);
             // Sanity check: messageID should be equal to limit now
             expect(currentMessageID).toBe(messageLimitA0);
@@ -238,7 +238,7 @@ describe("RLN", function () {
             }).rejects.toThrow("Message ID counter exceeded message limit")
         });
 
-        it("should fail to verify invalid proof", async function () {
+        test("should fail to verify invalid proof", async function () {
             const proofA00Invalid: RLNFullProof = {
                 ...proofA00,
                 snarkProof: {
@@ -252,7 +252,7 @@ describe("RLN", function () {
             expect(await rlnA0.verifyProof(epoch0, message0, proofA00Invalid)).toBeFalsy()
         });
 
-        it("should be able to withdraw", async function () {
+        test("should be able to withdraw", async function () {
             await rlnA0.withdraw();
             await waitUntilFreezePeriodPassed()
             await rlnA0.releaseWithdrawal();
@@ -260,13 +260,13 @@ describe("RLN", function () {
             expect((await rlnA0.getAllRateCommitments()).length).toBe(1);
         });
 
-        it("should fail to create proof after withdraw", async function () {
+        test("should fail to create proof after withdraw", async function () {
             await expect(async () => {
                 await rlnA0.createProof(epoch0, message0);
             }).rejects.toThrow("User has not registered before");
         });
 
-        it("should be able to get the latest state with A1", async function () {
+        test("should be able to get the latest state with A1", async function () {
             expect(await rlnA1.isRegistered()).toBe(false);
             const allRateCommitmentsA1 = await rlnA1.getAllRateCommitments();
             expect(allRateCommitmentsA1.length).toBe(1);
@@ -274,7 +274,7 @@ describe("RLN", function () {
             expect(await rlnA1.getMerkleRoot()).toBe(await rlnA0.getMerkleRoot());
         });
 
-        it("should be able to register A1", async function () {
+        test("should be able to register A1", async function () {
             await rlnA1.register(messageLimitA1, messageIDCounterA1);
             expect(await rlnA1.isRegistered()).toBe(true);
             const allRateCommitmentsA1 = await rlnA1.getAllRateCommitments();
@@ -282,7 +282,7 @@ describe("RLN", function () {
             expect(allRateCommitmentsA1[1]).toBe(await rlnA1.getRateCommitment());
         });
 
-        it("should reveal its secret by itself if A1 creates more than `messageLimitA1` messages", async function () {
+        test("should reveal its secret by itself if A1 creates more than `messageLimitA1` messages", async function () {
             // messageLimitA1 is 1, so A1 can only create 1 proof per epoch
             // Test: can save the first proof
             proofA10 = await rlnA1.createProof(epoch0, message0);
@@ -322,7 +322,7 @@ describe("RLN", function () {
             await rlnA1.createProof(epoch1, message1);
         });
 
-        it("should reveal its secret and get slashed by others", async function () {
+        test("should reveal its secret and get slashed by others", async function () {
             // Test: A0 is up-to-date and receives more than `messageLimitA1` proofs,
             // so A1's secret is breached by A0
             const resA10 = await rlnA0.saveProof(proofA10);
@@ -337,7 +337,7 @@ describe("RLN", function () {
             expect(await rlnA1.isRegistered()).toBe(false);
         });
 
-        it("should be incompatible for RLN if rlnIdentifier is different", async function () {
+        test("should be incompatible for RLN if rlnIdentifier is different", async function () {
             // Create another rlnInstance with different rlnIdentifier
             const rlnB = rlnInstanceFactory({
                 rlnIdentifier: rlnIdentifierB,

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -5,6 +5,7 @@ import { BigNumber } from '@ethersproject/bignumber'
 import { keccak256 } from '@ethersproject/keccak256'
 
 import { Fq } from "../src/common"
+import { MemoryMessageIDCounter } from "../src/message-id-counter";
 
 export function fieldFactory(excludes?: bigint[], trials: number = 100): bigint {
     if (excludes) {
@@ -17,6 +18,16 @@ export function fieldFactory(excludes?: bigint[], trials: number = 100): bigint 
         throw new Error("Failed to generate a random epoch")
     } else {
         return Fq.random()
+    }
+}
+
+export class FakeMessageIDCounter extends MemoryMessageIDCounter {
+    async peekNextMessageID(epoch: bigint): Promise<bigint> {
+        const epochStr = epoch.toString()
+        if (this.epochToMessageID[epochStr] === undefined) {
+          return BigInt(0)
+        }
+        return this.epochToMessageID[epochStr]
     }
 }
 


### PR DESCRIPTION
## What's wrong?
#47 

## How it is fixed?
- In `rln.createProof`, we also call `Cache.checkProof` to ensure the created proof does not breach in the prover's local view.
- Since `RLN.createProof` depends on `this.cache.checkProof` and `this.cache.addProof`, I've removed `this.verifier.verifyProof(proof)` from `RLN.addProve` otherwise the you need to be both prover and verifier to call `createProof`