### PR TITLE
Rename function and expose more APIs

### DIFF
--- a/src/common.ts
+++ b/src/common.ts
@@ -18,7 +18,7 @@ export const Fq = new ZqField(SNARK_FIELD_SIZE)
 
 export const DEFAULT_MERKLE_TREE_DEPTH = 20
 
-export function calculateIdentityCommitment(identity: Identity): bigint {
+export function calculateIdentitySecret(identity: Identity): bigint {
   return poseidon([
     identity.getNullifier(),
     identity.getTrapdoor(),

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,6 @@ export { IMessageIDCounter } from './message-id-counter'
 
 export * from './types'
 // Expose helpers
-export { calculateExternalNullifier,  calculateRateCommitment, calculateSignalHash, shamirRecovery } from "./common"
+export { calculateExternalNullifier,  calculateRateCommitment, calculateSignalHash, shamirRecovery } from './common'
 
 export { RLNFullProof, RLNSNARKProof, RLNWitness, RLNPublicSignals, RLNProver, RLNVerifier, WithdrawProver } from './circuit-wrapper'

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,5 +4,7 @@ export { CachedProof, ICache, MemoryCache, Status } from './cache'
 export { IMessageIDCounter } from './message-id-counter'
 
 export * from './types'
+// Expose helpers
+export { calculateExternalNullifier,  calculateRateCommitment, calculateSignalHash, shamirRecovery } from "./common"
 
 export { RLNFullProof, RLNSNARKProof, RLNWitness, RLNPublicSignals, RLNProver, RLNVerifier, WithdrawProver } from './circuit-wrapper'

--- a/src/rln.ts
+++ b/src/rln.ts
@@ -1,6 +1,6 @@
 import { Identity } from '@semaphore-protocol/identity'
 import { VerificationKey } from './types'
-import { DEFAULT_MERKLE_TREE_DEPTH, calculateIdentityCommitment, calculateSignalHash } from './common'
+import { DEFAULT_MERKLE_TREE_DEPTH, calculateIdentitySecret, calculateSignalHash } from './common'
 import { IRLNRegistry, ContractRLNRegistry } from './registry'
 import { MemoryCache, EvaluatedProof, ICache, Status } from './cache'
 import { IMessageIDCounter, MemoryMessageIDCounter } from './message-id-counter'
@@ -349,7 +349,7 @@ export class RLN implements IRLN {
   }
 
   private get identitySecret(): bigint {
-    return calculateIdentityCommitment(this.identity)
+    return calculateIdentitySecret(this.identity)
   }
 
   /**


### PR DESCRIPTION
## What's done?
- Rename: `calculateIdentityCommitment` -> `calculateIdentitySecret`
- Export helpers
  - `calculateExternalNullifier`
  - `calculateRateCommitment`
  - `calculateSignalHash`
  - `shamirRecovery`

