### PR TITLE
Update both browser and node examples to v3.2.0

### DIFF
--- a/examples/browser/package-lock.json
+++ b/examples/browser/package-lock.json
@@ -13,7 +13,7 @@
         "@rollup/plugin-json": "^6.0.0",
         "@rollup/plugin-node-resolve": "^15.0.2",
         "@rollup/plugin-replace": "^5.0.2",
-        "rlnjs": "^3.1.5",
+        "rlnjs": "^3.2.0",
         "rollup": "^3.20.2",
         "rollup-plugin-cleaner": "^1.0.0",
         "rollup-plugin-polyfill-node": "^0.12.0",
@@ -443,6 +443,21 @@
       "resolved": "https://registry.npmjs.org/async/-/async-3.2.4.tgz",
       "integrity": "sha512-iAB+JbDEGXhyIUavoDl9WP/Jj106Kz9DEn1DPgYw5ruDn0e3Wgi3sKFm55sASdGBNOQB8F59d9qQ7deqrHA8wQ=="
     },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
+    },
+    "node_modules/axios": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.5.0.tgz",
+      "integrity": "sha512-D4DdjDo5CY50Qms0qGQTTw6Q44jl7zRwY7bthds06pUGfChBCTcQs+N743eFWGEd6pRTMd6A+I87aWyFV5wiZQ==",
+      "dependencies": {
+        "follow-redirects": "^1.15.0",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
     "node_modules/b4a": {
       "version": "1.6.3",
       "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.6.3.tgz",
@@ -452,25 +467,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
-    },
-    "node_modules/base64-js": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
-      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ]
     },
     "node_modules/bfj": {
       "version": "7.0.2",
@@ -635,6 +631,17 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
     },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/commondir": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
@@ -659,6 +666,14 @@
       "integrity": "sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og==",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/ejs": {
@@ -819,6 +834,38 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/follow-redirects": {
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
+      "integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/fs.realpath": {
@@ -1107,6 +1154,25 @@
         "semver": "bin/semver.js"
       }
     },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/minimalistic-assert": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
@@ -1245,6 +1311,11 @@
       "resolved": "https://registry.npmjs.org/poseidon-lite/-/poseidon-lite-0.0.2.tgz",
       "integrity": "sha512-bGdDPTOQkJbBjbtSEWc3gY+YhqlGTxGlZ8041F8TGGg5QyGGp1Cfs4b8AEnFFjHbkPg6WdWXUgEjU1GKOKWAPw=="
     },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
+    },
     "node_modules/r1csfile": {
       "version": "0.0.45",
       "resolved": "https://registry.npmjs.org/r1csfile/-/r1csfile-0.0.45.tgz",
@@ -1334,9 +1405,9 @@
       }
     },
     "node_modules/rlnjs": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/rlnjs/-/rlnjs-3.1.5.tgz",
-      "integrity": "sha512-dBsA2EZVqXDOnhtd12FNndD1bAuErbH2MJCQmw3YrJly2Au2c9Lp6GXE/UB71eUgXHLeJAqPxv2EMXix64Ij4A==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/rlnjs/-/rlnjs-3.2.0.tgz",
+      "integrity": "sha512-+9mqWafWbsfflMR01HV61BcFFxZ5XJLU4pa/qWHxbVvU9mAcl6UKr0UE7clS9oogoGIu/NPjTDIHmkFfBgqgXg==",
       "dependencies": {
         "@ethersproject/bytes": "^5.7.0",
         "@ethersproject/keccak256": "^5.7.0",
@@ -1345,7 +1416,7 @@
         "@semaphore-protocol/group": "^3.10.1",
         "@semaphore-protocol/identity": "^3.10.1",
         "@zk-kit/incremental-merkle-tree": "^0.4.3",
-        "base64-js": "^1.5.1",
+        "axios": "^1.5.0",
         "ethers": "^6.4.0",
         "ffjavascript": "0.2.55",
         "poseidon-lite": "^0.0.2",

--- a/examples/browser/package.json
+++ b/examples/browser/package.json
@@ -21,6 +21,6 @@
     "rollup-plugin-polyfill-node": "^0.12.0",
     "rollup-plugin-typescript2": "^0.34.1",
     "rollup-plugin-visualizer": "^5.9.0",
-    "rlnjs": "^3.1.5"
+    "rlnjs": "^3.2.0"
   }
 }

--- a/examples/browser/src/index.ts
+++ b/examples/browser/src/index.ts
@@ -1,5 +1,5 @@
 import { ethers } from "ethers";
-import { MemoryCache, RLN, Status } from "test-rlnjs";
+import { MemoryCache, RLN, Status } from "rlnjs";
 import { deployERC20, deployRLNContract, deployVerifier, treeDepth, url } from "./configs";
 
 
@@ -42,8 +42,8 @@ async function main() {
     const rlnContractAtBlock = await provider.getBlockNumber()
     console.log(`Deployed RLN contract at ${rlnContractAddress} at block ${rlnContractAtBlock}`)
 
-    function createRLNInstance() {
-        return RLN.createWithContractRegistry({
+    async function createRLNInstance() {
+        return await RLN.createWithContractRegistry({
             /* Required */
             rlnIdentifier,
             provider,
@@ -58,7 +58,7 @@ async function main() {
         provider.send("hardhat_mine", ["0x" + numBlocks.toString(16)])
     }
 
-    const rln = createRLNInstance()
+    const rln = await createRLNInstance()
     console.log(`rln created: identityCommitment=${rln.identityCommitment}`)
     if (await rln.isRegistered()) {
         throw new Error(`rln should not have yet registered`);
@@ -116,7 +116,7 @@ async function main() {
         }
     }
     const resettableCache = new ResettableCache()
-    const rlnAnother = createRLNInstance()
+    const rlnAnother = await createRLNInstance()
     rlnAnother.setCache(resettableCache)
     console.log(`rlnAnother created: identityCommitment=${rlnAnother.identityCommitment}`)
     class FaultyMessageIDCounter {
@@ -157,7 +157,7 @@ async function main() {
     if (await rlnAnother.isRegistered()) {
         throw new Error(`rlnAnother should have been slashed`);
     }
-    console.log(`Successfully slashed rlnAnother`);
+    console.log(`Completed successfully`)
     RLN.cleanUp()
 }
 

--- a/examples/browser/tsconfig.json
+++ b/examples/browser/tsconfig.json
@@ -5,7 +5,6 @@
     "moduleResolution": "node",
     "allowJs": true,
     "allowSyntheticDefaultImports": true,
-    "noUnusedLocals": true,
     "noUnusedParameters": true,
     "noImplicitAny": false,
     "noImplicitReturns": true,

--- a/examples/node/package-lock.json
+++ b/examples/node/package-lock.json
@@ -10,7 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "ethers": "^6.6.0",
-        "rlnjs": "^3.1.5"
+        "rlnjs": "^3.2.0"
       },
       "devDependencies": {
         "hardhat": "^2.15.0"
@@ -1934,6 +1934,21 @@
       "resolved": "https://registry.npmjs.org/async/-/async-3.2.4.tgz",
       "integrity": "sha512-iAB+JbDEGXhyIUavoDl9WP/Jj106Kz9DEn1DPgYw5ruDn0e3Wgi3sKFm55sASdGBNOQB8F59d9qQ7deqrHA8wQ=="
     },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
+    },
+    "node_modules/axios": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.5.0.tgz",
+      "integrity": "sha512-D4DdjDo5CY50Qms0qGQTTw6Q44jl7zRwY7bthds06pUGfChBCTcQs+N743eFWGEd6pRTMd6A+I87aWyFV5wiZQ==",
+      "dependencies": {
+        "follow-redirects": "^1.15.0",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
     "node_modules/b4a": {
       "version": "1.6.4",
       "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.6.4.tgz",
@@ -1957,6 +1972,7 @@
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
       "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -2371,6 +2387,17 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
     },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/command-exists": {
       "version": "1.2.9",
       "resolved": "https://registry.npmjs.org/command-exists/-/command-exists-1.2.9.tgz",
@@ -2463,6 +2490,14 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/depd": {
@@ -2799,7 +2834,6 @@
       "version": "1.15.2",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
       "integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==",
-      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -2813,6 +2847,19 @@
         "debug": {
           "optional": true
         }
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/fp-ts": {
@@ -3636,6 +3683,25 @@
         "node": ">= 0.10.0"
       }
     },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/minimalistic-assert": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
@@ -4030,6 +4096,11 @@
       "resolved": "https://registry.npmjs.org/poseidon-lite/-/poseidon-lite-0.0.2.tgz",
       "integrity": "sha512-bGdDPTOQkJbBjbtSEWc3gY+YhqlGTxGlZ8041F8TGGg5QyGGp1Cfs4b8AEnFFjHbkPg6WdWXUgEjU1GKOKWAPw=="
     },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
+    },
     "node_modules/qs": {
       "version": "6.11.2",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.11.2.tgz",
@@ -4202,9 +4273,9 @@
       }
     },
     "node_modules/rlnjs": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/rlnjs/-/rlnjs-3.1.5.tgz",
-      "integrity": "sha512-dBsA2EZVqXDOnhtd12FNndD1bAuErbH2MJCQmw3YrJly2Au2c9Lp6GXE/UB71eUgXHLeJAqPxv2EMXix64Ij4A==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/rlnjs/-/rlnjs-3.2.0.tgz",
+      "integrity": "sha512-+9mqWafWbsfflMR01HV61BcFFxZ5XJLU4pa/qWHxbVvU9mAcl6UKr0UE7clS9oogoGIu/NPjTDIHmkFfBgqgXg==",
       "dependencies": {
         "@ethersproject/bytes": "^5.7.0",
         "@ethersproject/keccak256": "^5.7.0",
@@ -4213,7 +4284,7 @@
         "@semaphore-protocol/group": "^3.10.1",
         "@semaphore-protocol/identity": "^3.10.1",
         "@zk-kit/incremental-merkle-tree": "^0.4.3",
-        "base64-js": "^1.5.1",
+        "axios": "^1.5.0",
         "ethers": "^6.4.0",
         "ffjavascript": "0.2.55",
         "poseidon-lite": "^0.0.2",
@@ -6256,6 +6327,21 @@
       "resolved": "https://registry.npmjs.org/async/-/async-3.2.4.tgz",
       "integrity": "sha512-iAB+JbDEGXhyIUavoDl9WP/Jj106Kz9DEn1DPgYw5ruDn0e3Wgi3sKFm55sASdGBNOQB8F59d9qQ7deqrHA8wQ=="
     },
+    "asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
+    },
+    "axios": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.5.0.tgz",
+      "integrity": "sha512-D4DdjDo5CY50Qms0qGQTTw6Q44jl7zRwY7bthds06pUGfChBCTcQs+N743eFWGEd6pRTMd6A+I87aWyFV5wiZQ==",
+      "requires": {
+        "follow-redirects": "^1.15.0",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
     "b4a": {
       "version": "1.6.4",
       "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.6.4.tgz",
@@ -6278,7 +6364,8 @@
     "base64-js": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
-      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "dev": true
     },
     "bech32": {
       "version": "1.1.4",
@@ -6601,6 +6688,14 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
     },
+    "combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "requires": {
+        "delayed-stream": "~1.0.0"
+      }
+    },
     "command-exists": {
       "version": "1.2.9",
       "resolved": "https://registry.npmjs.org/command-exists/-/command-exists-1.2.9.tgz",
@@ -6671,6 +6766,11 @@
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-4.0.0.tgz",
       "integrity": "sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ==",
       "dev": true
+    },
+    "delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="
     },
     "depd": {
       "version": "2.0.0",
@@ -6950,8 +7050,17 @@
     "follow-redirects": {
       "version": "1.15.2",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
-      "integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==",
-      "dev": true
+      "integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA=="
+    },
+    "form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "requires": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      }
     },
     "fp-ts": {
       "version": "1.19.3",
@@ -7546,6 +7655,19 @@
       "integrity": "sha512-S3UwM3yj5mtUSEfP41UZmt/0SCoVYUcU1rkXv+BQ5Ig8ndL4sPoJNBUJERafdPb5jjHJGuMgytgKvKIf58XNBw==",
       "dev": true
     },
+    "mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="
+    },
+    "mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "requires": {
+        "mime-db": "1.52.0"
+      }
+    },
     "minimalistic-assert": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
@@ -7836,6 +7958,11 @@
       "resolved": "https://registry.npmjs.org/poseidon-lite/-/poseidon-lite-0.0.2.tgz",
       "integrity": "sha512-bGdDPTOQkJbBjbtSEWc3gY+YhqlGTxGlZ8041F8TGGg5QyGGp1Cfs4b8AEnFFjHbkPg6WdWXUgEjU1GKOKWAPw=="
     },
+    "proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
+    },
     "qs": {
       "version": "6.11.2",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.11.2.tgz",
@@ -7969,9 +8096,9 @@
       }
     },
     "rlnjs": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/rlnjs/-/rlnjs-3.1.5.tgz",
-      "integrity": "sha512-dBsA2EZVqXDOnhtd12FNndD1bAuErbH2MJCQmw3YrJly2Au2c9Lp6GXE/UB71eUgXHLeJAqPxv2EMXix64Ij4A==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/rlnjs/-/rlnjs-3.2.0.tgz",
+      "integrity": "sha512-+9mqWafWbsfflMR01HV61BcFFxZ5XJLU4pa/qWHxbVvU9mAcl6UKr0UE7clS9oogoGIu/NPjTDIHmkFfBgqgXg==",
       "requires": {
         "@ethersproject/bytes": "^5.7.0",
         "@ethersproject/keccak256": "^5.7.0",
@@ -7980,7 +8107,7 @@
         "@semaphore-protocol/group": "^3.10.1",
         "@semaphore-protocol/identity": "^3.10.1",
         "@zk-kit/incremental-merkle-tree": "^0.4.3",
-        "base64-js": "^1.5.1",
+        "axios": "^1.5.0",
         "ethers": "^6.4.0",
         "ffjavascript": "0.2.55",
         "poseidon-lite": "^0.0.2",

--- a/examples/node/package.json
+++ b/examples/node/package.json
@@ -11,7 +11,7 @@
   "license": "ISC",
   "dependencies": {
     "ethers": "^6.6.0",
-    "rlnjs": "^3.1.5"
+    "rlnjs": "^3.2.0"
   },
   "devDependencies": {
     "hardhat": "^2.15.0"

--- a/examples/node/src/index.ts
+++ b/examples/node/src/index.ts
@@ -1,5 +1,5 @@
 import { ethers } from "ethers";
-import { MemoryCache, RLN, Status } from "test-rlnjs";
+import { MemoryCache, RLN, Status } from "rlnjs";
 import { deployERC20, deployRLNContract, deployVerifier, treeDepth, url } from "./configs";
 
 
@@ -42,8 +42,8 @@ async function main() {
     const rlnContractAtBlock = await provider.getBlockNumber()
     console.log(`Deployed RLN contract at ${rlnContractAddress} at block ${rlnContractAtBlock}`)
 
-    function createRLNInstance() {
-        return RLN.createWithContractRegistry({
+    async function createRLNInstance() {
+        return await RLN.createWithContractRegistry({
             /* Required */
             rlnIdentifier,
             provider,
@@ -58,7 +58,7 @@ async function main() {
         provider.send("hardhat_mine", ["0x" + numBlocks.toString(16)])
     }
 
-    const rln = createRLNInstance()
+    const rln = await createRLNInstance()
     console.log(`rln created: identityCommitment=${rln.identityCommitment}`)
     if (await rln.isRegistered()) {
         throw new Error(`rln should not have yet registered`);
@@ -116,7 +116,7 @@ async function main() {
         }
     }
     const resettableCache = new ResettableCache()
-    const rlnAnother = createRLNInstance()
+    const rlnAnother = await createRLNInstance()
     rlnAnother.setCache(resettableCache)
     console.log(`rlnAnother created: identityCommitment=${rlnAnother.identityCommitment}`)
     class FaultyMessageIDCounter {
@@ -157,7 +157,7 @@ async function main() {
     if (await rlnAnother.isRegistered()) {
         throw new Error(`rlnAnother should have been slashed`);
     }
-    console.log(`Successfully slashed rlnAnother`);
+    console.log(`Completed successfully`)
     RLN.cleanUp()
 }
 


### PR DESCRIPTION
## What's wrong?
v3.2.0 made changes to API. Fix the examples accordingly.

## How it is fixed?
- Update rlnjs deps version
- Call `await createWithContractRegistry()` instead of `createWithContractRegistry()`