### PR TITLE
feat: expose more API

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "test-rlnjs",
+  "name": "rlnjs",
   "version": "3.2.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "test-rlnjs",
+      "name": "rlnjs",
       "version": "3.2.1",
       "license": "MIT",
       "dependencies": {

--- a/src/common.ts
+++ b/src/common.ts
@@ -57,3 +57,7 @@ export function shamirRecovery(x1: bigint, x2: bigint, y1: bigint, y2: bigint): 
 
   return Fq.normalize(privateKey)
 }
+
+export function calculateIdentityCommitment(identitySecret: bigint) {
+  return poseidon([identitySecret])
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,10 +1,10 @@
 export { IRLN, RLN } from './rln'
 export { ContractRLNRegistry, IRLNRegistry, MemoryRLNRegistry } from './registry'
 export { CachedProof, ICache, MemoryCache, Status } from './cache'
-export { IMessageIDCounter } from './message-id-counter'
+export { IMessageIDCounter, MemoryMessageIDCounter } from './message-id-counter'
 
 export * from './types'
 // Expose helpers
-export { calculateExternalNullifier,  calculateRateCommitment, calculateSignalHash, shamirRecovery, DEFAULT_MERKLE_TREE_DEPTH } from './common'
+export { calculateExternalNullifier,  calculateRateCommitment, calculateSignalHash, shamirRecovery, calculateIdentityCommitment, DEFAULT_MERKLE_TREE_DEPTH } from './common'
 
 export { RLNFullProof, RLNSNARKProof, RLNWitness, RLNPublicSignals, RLNProver, RLNVerifier, WithdrawProver } from './circuit-wrapper'

--- a/src/registry.ts
+++ b/src/registry.ts
@@ -1,6 +1,6 @@
 import { Group } from '@semaphore-protocol/group'
 import { MerkleProof } from './types'
-import { DEFAULT_MERKLE_TREE_DEPTH, calculateRateCommitment } from './common'
+import { DEFAULT_MERKLE_TREE_DEPTH, calculateIdentityCommitment, calculateRateCommitment } from './common'
 import { RLNContract } from './contract-wrapper'
 import { ethers } from 'ethers'
 import poseidon from 'poseidon-lite'
@@ -126,7 +126,7 @@ export class ContractRLNRegistry implements IRLNRegistry {
     if (this.withdrawProver === undefined) {
       throw new Error('Withdraw prover is not initialized')
     }
-    const identityCommitment = poseidon([identitySecret])
+    const identityCommitment = calculateIdentityCommitment(identitySecret)
     const user = await this.rlnContract.getUser(identityCommitment)
     if (user.userAddress === ethers.ZeroAddress) {
       throw new Error('Identity commitment is not registered')
@@ -158,7 +158,7 @@ export class ContractRLNRegistry implements IRLNRegistry {
     if (this.withdrawProver === undefined) {
       throw new Error('Withdraw prover is not initialized')
     }
-    const identityCommitment = poseidon([identitySecret])
+    const identityCommitment = calculateIdentityCommitment(identitySecret)
     receiver = receiver ? receiver : await this.rlnContract.getSignerAddress()
     const receiverBigInt = BigInt(receiver)
 
@@ -236,7 +236,7 @@ export class MemoryRLNRegistry implements IRLNRegistry {
   }
 
   async withdraw(identitySecret: bigint): Promise<void> {
-    const identityCommitment = poseidon([identitySecret])
+    const identityCommitment = calculateIdentityCommitment(identitySecret)
     if (!await this.isRegistered(identityCommitment)) {
       throw new Error('Identity commitment is not registered')
     }
@@ -264,7 +264,7 @@ export class MemoryRLNRegistry implements IRLNRegistry {
   }
 
   async slash(identitySecret: bigint, _?: string): Promise<void> {
-    const identityCommitment = poseidon([identitySecret])
+    const identityCommitment = calculateIdentityCommitment(identitySecret)
     const rateCommitment = await this.getRateCommitment(identityCommitment)
     const index = this.group.indexOf(rateCommitment)
     if (index === -1) {

--- a/src/rln.ts
+++ b/src/rln.ts
@@ -71,19 +71,19 @@ export class RLN implements IRLN {
   readonly identity: Identity
 
   // the prover allows user to generate proof with the RLN circuit
-  private prover?: RLNProver
+  prover?: RLNProver
 
   // the verifier allows user to verify proof with the RLN circuit
-  private verifier?: RLNVerifier
+  verifier?: RLNVerifier
 
   // the registry that stores the registered users
-  private registry: IRLNRegistry
+  registry: IRLNRegistry
 
   // the cache that stores proofs added by the user with `addProof`, and detect spams automatically
-  private cache: ICache
+  cache: ICache
 
   // the messageIDCounter is used to **safely** generate the latest messageID for the user
-  public messageIDCounter?: IMessageIDCounter
+  messageIDCounter?: IMessageIDCounter
 
   constructor(args: {
     /** Required */
@@ -436,6 +436,18 @@ export class RLN implements IRLN {
    */
   async isRegistered(): Promise<boolean> {
     return this.registry.isRegistered(this.identityCommitment)
+  }
+
+  async getMessageLimit(): Promise<bigint> {
+    return this.registry.getMessageLimit(this.identityCommitment)
+  }
+
+  async isUserRegistered(identityCommitment: bigint): Promise<boolean> {
+    return this.registry.isRegistered(identityCommitment)
+  }
+
+  async getMessageLimitForUser(identityCommitment: bigint): Promise<bigint> {
+    return this.registry.getMessageLimit(identityCommitment)
   }
 
   /**

--- a/tests/circuit-wrapper.test.ts
+++ b/tests/circuit-wrapper.test.ts
@@ -2,7 +2,7 @@ import { RLNProver, RLNVerifier, WithdrawProver, WithdrawVerifier } from '../src
 import { rlnParams, withdrawParams } from './configs';
 import { fieldFactory, generateMerkleProof } from './utils';
 import poseidon from 'poseidon-lite';
-import { DEFAULT_MERKLE_TREE_DEPTH } from '../src/common';
+import { DEFAULT_MERKLE_TREE_DEPTH, calculateIdentityCommitment } from '../src/common';
 
 // `userMessageLimit` is at most 16 bits
 // Ref: https://github.com/Rate-Limiting-Nullifier/rln-circuits-v2/blob/b40dfa63b7b1248527d7ab417d0d9cf538cad93a/circuits/utils.circom#L36-L37
@@ -13,7 +13,7 @@ describe('RLN', function () {
   const rlnProver = new RLNProver(rlnParams.wasmFilePath, rlnParams.finalZkeyPath);
   const rlnVerifier = new RLNVerifier(rlnParams.verificationKey);
   const identitySecret = fieldFactory();
-  const identityCommitment = poseidon([identitySecret]);
+  const identityCommitment = calculateIdentityCommitment(identitySecret);
   const leaves = [identityCommitment];
   const userMessageLimit = (BigInt(1) << BigInt(LIMIT_BIT_SIZE)) - BigInt(1);
   const messageId = BigInt(0);

--- a/tests/rln-registry.test.ts
+++ b/tests/rln-registry.test.ts
@@ -1,5 +1,5 @@
 import { IncrementalMerkleTree } from "@zk-kit/incremental-merkle-tree"
-import { calculateRateCommitment } from '../src/common';
+import { calculateIdentityCommitment, calculateRateCommitment } from '../src/common';
 import { ContractRLNRegistry, MemoryRLNRegistry, IRLNRegistry } from '../src/registry'
 import { fieldFactory } from './utils';
 import poseidon from "poseidon-lite";
@@ -18,8 +18,8 @@ describe('MemoryRLNRegistry', () => {
   const rlnIdentifier = BigInt(1)
   const identitySecret0 = fieldFactory();
   const identitySecret1 = fieldFactory([identitySecret0]);
-  const identityCommitment0 = poseidon([identitySecret0]);
-  const identityCommitment1 = poseidon([identitySecret1]);
+  const identityCommitment0 = calculateIdentityCommitment(identitySecret0);
+  const identityCommitment1 = calculateIdentityCommitment(identitySecret1);
 
   const messageLimit0 = BigInt(100)
   const messageLimit1 = BigInt(101)
@@ -124,8 +124,8 @@ describe('ContractRLNRegistry', () => {
   const rlnIdentifier = BigInt(1)
   const identitySecret0 = fieldFactory();
   const identitySecret1 = fieldFactory([identitySecret0]);
-  const identityCommitment0 = poseidon([identitySecret0]);
-  const identityCommitment1 = poseidon([identitySecret1]);
+  const identityCommitment0 = calculateIdentityCommitment(identitySecret0);
+  const identityCommitment1 = calculateIdentityCommitment(identitySecret1);
 
   const messageLimit0 = BigInt(100)
   const messageLimit1 = BigInt(101)


### PR DESCRIPTION
## What's done?
Expose more API
- `calculateIdentityCommitment`
- private members of RLN class, for easier testing
- Add new functions to query users' message limit and if they're registered