### PR TITLE
Expose default params and create message id counter in createProof if not present

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@ export { IRLN, RLN } from './rln'
 export { ContractRLNRegistry, IRLNRegistry, MemoryRLNRegistry } from './registry'
 export { CachedProof, ICache, MemoryCache, Status } from './cache'
 export { IMessageIDCounter, MemoryMessageIDCounter } from './message-id-counter'
+export { getDefaultRLNParams, getDefaultWithdrawParams } from './resources'
 
 export * from './types'
 // Expose helpers

--- a/tests/circuit-wrapper.test.ts
+++ b/tests/circuit-wrapper.test.ts
@@ -1,7 +1,6 @@
 import { RLNProver, RLNVerifier, WithdrawProver, WithdrawVerifier } from '../src/circuit-wrapper';
 import { rlnParams, withdrawParams } from './configs';
 import { fieldFactory, generateMerkleProof } from './utils';
-import poseidon from 'poseidon-lite';
 import { DEFAULT_MERKLE_TREE_DEPTH, calculateIdentityCommitment } from '../src/common';
 
 // `userMessageLimit` is at most 16 bits


### PR DESCRIPTION
## What is done?
- Expose API `getDefaultRLNParams` and `getDefaultWithdrawParams`: allows devs to download default params before initiating RLN instance. It can save bandwidth and loading time when there are multiple RLN instances instantiated with default params since by default they will download the same files multiple times.
- If `createProof` while a message id counter is not set (possible when restarting an app), set a new `MemoryMessageIDCounter` and emit a warning that user will risk being slashed if it's still the same epoch and user has sent messages before.