### PR TITLE
change to permanent urls

### DIFF
--- a/src/resources.ts
+++ b/src/resources.ts
@@ -3,17 +3,17 @@ import { VerificationKey } from './types'
 import axios from 'axios'
 
 type ICircuitParams = {
-  wasmFile: string | Uint8Array,
-  finalZkey: string | Uint8Array,
+  wasmFile: string | Uint8Array;
+  finalZkey: string | Uint8Array;
 }
 
 type IRLNParams = ICircuitParams & { verificationKey: VerificationKey }
 type IWithdrawParams = ICircuitParams
 
-// TODO: Change to a more permanent URL after trusted setup is complete
-const resourcesURL = 'https://rln-resources-temp.s3.us-west-1.amazonaws.com/resources'
+const resourcesURL =
+  'https://rln-trusted-setup-ceremony-pse-p0tion-production.s3.eu-central-1.amazonaws.com/circuits'
 const rln20URL = `${resourcesURL}/rln-20`
-const withdrawURL = `${resourcesURL}/withdraw`
+const withdrawURL = `${resourcesURL}/rln-withdraw`
 const treeDepthToDefaultRLNParamsURL = {
   '20': rln20URL,
 }
@@ -32,7 +32,8 @@ function parseVerificationKeyJSON(o: any): VerificationKey {
   if (!o.vk_beta_2) throw new Error('Verification key has no vk_beta_2')
   if (!o.vk_gamma_2) throw new Error('Verification key has no vk_gamma_2')
   if (!o.vk_delta_2) throw new Error('Verification key has no vk_delta_2')
-  if (!o.vk_alphabeta_12) throw new Error('Verification key has no vk_alphabeta_12')
+  if (!o.vk_alphabeta_12)
+    throw new Error('Verification key has no vk_alphabeta_12')
   if (!o.IC) throw new Error('Verification key has no IC')
   return o
 }
@@ -47,9 +48,12 @@ export async function getDefaultRLNParams(treeDepth: number): Promise<IRLNParams
   if (!url) {
     return undefined
   }
-  const wasmFileURL = `${url}/circuit.wasm`
-  const finalZkeyURL = `${url}/final.zkey`
-  const verificationKeyURL = `${url}/verification_key.json`
+  const wasmFileURL = `${url}/RLN-20.wasm`
+  const finalZkeyURL = `${url}/contributions/rln-20_final.zkey`
+  console.log(url)
+  console.log(wasmFileURL)
+  console.log(finalZkeyURL)
+  const verificationKeyURL = `${url}/rln-20_vkey.json`
   const verificationKey = await downloadVerificationKey(verificationKeyURL)
   const [wasmFile, finalZkey] = await Promise.all([
     downloadBinary(wasmFileURL),
@@ -63,8 +67,8 @@ export async function getDefaultRLNParams(treeDepth: number): Promise<IRLNParams
 }
 
 export async function getDefaultWithdrawParams(): Promise<IWithdrawParams> {
-  const wasmFileURL = `${withdrawURL}/circuit.wasm`
-  const finalZkeyURL = `${withdrawURL}/final.zkey`
+  const wasmFileURL = `${withdrawURL}/RLN-Withdraw.wasm`
+  const finalZkeyURL = `${withdrawURL}/contributions/rln-withdraw_final.zkey`
   const [wasmFile, finalZkey] = await Promise.all([
     downloadBinary(wasmFileURL),
     downloadBinary(finalZkeyURL),
@@ -74,5 +78,3 @@ export async function getDefaultWithdrawParams(): Promise<IWithdrawParams> {
     finalZkey,
   }
 }
-
-

--- a/src/resources.ts
+++ b/src/resources.ts
@@ -50,9 +50,6 @@ export async function getDefaultRLNParams(treeDepth: number): Promise<IRLNParams
   }
   const wasmFileURL = `${url}/RLN-20.wasm`
   const finalZkeyURL = `${url}/contributions/rln-20_final.zkey`
-  console.log(url)
-  console.log(wasmFileURL)
-  console.log(finalZkeyURL)
   const verificationKeyURL = `${url}/rln-20_vkey.json`
   const verificationKey = await downloadVerificationKey(verificationKeyURL)
   const [wasmFile, finalZkey] = await Promise.all([


### PR DESCRIPTION
#100 

## What's wrong?
Right now we're using a temporary resource, as mentioned in

[rlnjs/src/resources.ts](https://github.com/Rate-Limiting-Nullifier/rlnjs/blob/7a4a5afa88789408b2b925c89db2d7de289e7127/src/resources.ts#L13)

Line 13 in [7a4a5af](https://github.com/Rate-Limiting-Nullifier/rlnjs/commit/7a4a5afa88789408b2b925c89db2d7de289e7127)

## How to fix
- I change to some links in the below url
https://github.com/Rate-Limiting-Nullifier/rlnjs/issues/100#issue-1880028395

## Problem
If you try "npm test", one test fails out of seven.
That's because the below wasm link produce a "r1cs" file.
Now, people in trusted setup team are researching the cause.

Test Error Meassage
```
nt@MacBook-Air rlnjs % npm test

> rlnjs@3.2.0 test
> jest

 PASS  tests/field-artithmetics.test.ts
 PASS  tests/message-id-counter.test.ts
 PASS  tests/cache.test.ts (6.75 s)
 PASS  tests/circuit-wrapper.test.ts (6.959 s)
 PASS  tests/rln-registry.test.ts (27.872 s)
 PASS  tests/contract.test.ts (53.345 s)
 FAIL  tests/rln.test.ts (54.942 s)
  ● RLN › functionalities › should be able to create proof

    CompileError: WebAssembly.compile(): expected magic word 00 61 73 6d, found 72 31 63 73 @+0



A worker process has failed to exit gracefully and has been force exited. This is likely caused by tests leaking due to improper teardown. Try running with --detectOpenHandles to find leaks. Active timers can also cause this, ensure that .unref() was called on them.
------------------------|---------|----------|---------|---------|----------------------------------------------------------------------------------------------
File                    | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s                                                                            
------------------------|---------|----------|---------|---------|----------------------------------------------------------------------------------------------
All files               |   81.79 |    57.14 |   77.61 |   82.82 |                                                                                              
 src                    |   80.34 |    58.49 |   77.39 |   80.57 |                                                                                              
  cache.ts              |   94.23 |     87.5 |   88.88 |   93.47 | 154,161-162                                                                                  
  circuit-wrapper.ts    |   97.36 |    66.66 |     100 |   96.87 | 132                                                                                          
  common.ts             |     100 |      100 |     100 |     100 |                                                                                              
  contract-wrapper.ts   |   92.15 |       75 |   88.23 |    90.9 | 97-100,107,149,179-180                                                                       
  index.ts              |     100 |      100 |   15.38 |     100 |                                                                                              
  message-id-counter.ts |     100 |      100 |     100 |     100 |                                                                                              
  registry.ts           |   70.52 |     43.9 |   82.14 |   70.83 | 50,60,79-81,106,113,120,126-140,144-151,155-166,218,239,249,253,261-270                      
  resources.ts          |   82.35 |       25 |     100 |   97.36 | 36                                                                                           
  rln.ts                |   67.29 |    57.37 |   68.18 |   67.12 | ...9,212,381,386-387,404,455,468,475-476,486,497,507,529-543,556,562-585,595-597,601-603,614 
 tests                  |    87.5 |    47.82 |   78.94 |   92.12 |                                                                                              
  configs.ts            |      70 |        0 |     100 |     100 | 10-18                                                                                        
  factories.ts          |   94.25 |    66.66 |      80 |   92.85 | 36,43,64,103,112                                                                             
  utils.ts              |   86.04 |      100 |   71.42 |   86.11 | 18,42-45                                                                                     
------------------------|---------|----------|---------|---------|----------------------------------------------------------------------------------------------
Test Suites: 1 failed, 6 passed, 7 total
Tests:       1 failed, 45 passed, 46 total
Snapshots:   0 total
Time:        55.898 s
Force exiting Jest: Have you considered using `--detectOpenHandles` to detect async operations that kept running after all tests finished?
```

