### PR TITLE
check if wasm and zkey exist

### DIFF
--- a/src/common.ts
+++ b/src/common.ts
@@ -66,16 +66,16 @@ export function calculateIdentityCommitment(identitySecret: bigint) {
 
 export function isValidUrl(str: string): boolean {
   try {
-      new URL(str)
-      return true
+    new URL(str)
+    return true
   } catch (_) {
-      return false
+    return false
   }
 }
 
 export async function checkFileExistsOnWeb(url: string): Promise<boolean> {
   try {
-    await axios.head(url);
+    await axios.head(url)
     return true
   } catch (error) {
     return false
@@ -84,12 +84,12 @@ export async function checkFileExistsOnWeb(url: string): Promise<boolean> {
 
 export async function checkFileExists(path: string): Promise<boolean> {
   if (isValidUrl(path)) {
-    return await checkFileExistsOnWeb(path)
+    return checkFileExistsOnWeb(path)
   } else {
 
     if (typeof window !== 'undefined' && typeof window.document !== 'undefined') {
       throw new Error(
-        'not allowed to read local files from browser'
+        'not allowed to read local files from browser',
       )
     }
 

--- a/src/common.ts
+++ b/src/common.ts
@@ -92,7 +92,7 @@ export async function checkFileExists(path: string): Promise<boolean> {
       )
     }
 
-    const fs = await import("fs")
+    const fs = await import('fs')
     return fs.existsSync(path)
   }
 }

--- a/src/common.ts
+++ b/src/common.ts
@@ -86,7 +86,7 @@ export async function checkFileExists(path: string): Promise<boolean> {
     return await checkFileExistsOnWeb(path)
   } else {
 
-    if (typeof process === 'undefined') {
+    if (typeof process === 'undefined' && typeof window !=='undefined') {
       throw new Error(
         'not allowed to read local files from browser',
       )

--- a/src/common.ts
+++ b/src/common.ts
@@ -7,7 +7,6 @@ import { ZqField } from 'ffjavascript'
 import poseidon from 'poseidon-lite'
 import { Identity } from '@semaphore-protocol/identity'
 import axios from 'axios'
-import fs from 'fs'
 
 /*
   This is the "Baby Jubjub" curve described here:
@@ -87,12 +86,13 @@ export async function checkFileExists(path: string): Promise<boolean> {
     return await checkFileExistsOnWeb(path)
   } else {
 
-    if (typeof window !== 'undefined' && typeof window.document !== 'undefined') {
+    if (typeof process === 'undefined') {
       throw new Error(
         'not allowed to read local files from browser',
       )
     }
 
+    const fs = await import("fs")
     return fs.existsSync(path)
   }
 }

--- a/src/common.ts
+++ b/src/common.ts
@@ -86,7 +86,7 @@ export async function checkFileExists(path: string): Promise<boolean> {
     return await checkFileExistsOnWeb(path)
   } else {
 
-    if (typeof process === 'undefined' && typeof window !=='undefined') {
+    if (typeof process === 'undefined' && typeof window !== 'undefined') {
       throw new Error(
         'not allowed to read local files from browser',
       )

--- a/src/common.ts
+++ b/src/common.ts
@@ -6,6 +6,8 @@ import { ZqField } from 'ffjavascript'
 
 import poseidon from 'poseidon-lite'
 import { Identity } from '@semaphore-protocol/identity'
+import axios from 'axios'
+import fs from 'fs'
 
 /*
   This is the "Baby Jubjub" curve described here:
@@ -60,4 +62,37 @@ export function shamirRecovery(x1: bigint, x2: bigint, y1: bigint, y2: bigint): 
 
 export function calculateIdentityCommitment(identitySecret: bigint) {
   return poseidon([identitySecret])
+}
+
+export function isValidUrl(str: string): boolean {
+  try {
+      new URL(str)
+      return true
+  } catch (_) {
+      return false
+  }
+}
+
+export async function checkFileExistsOnWeb(url: string): Promise<boolean> {
+  try {
+    await axios.head(url);
+    return true
+  } catch (error) {
+    return false
+  }
+}
+
+export async function checkFileExists(path: string): Promise<boolean> {
+  if (isValidUrl(path)) {
+    return await checkFileExistsOnWeb(path)
+  } else {
+
+    if (typeof window !== 'undefined' && typeof window.document !== 'undefined') {
+      throw new Error(
+        'not allowed to read local files from browser'
+      )
+    }
+
+    return fs.existsSync(path)
+  }
 }

--- a/src/common.ts
+++ b/src/common.ts
@@ -84,7 +84,7 @@ export async function checkFileExistsOnWeb(url: string): Promise<boolean> {
 
 export async function checkFileExists(path: string): Promise<boolean> {
   if (isValidUrl(path)) {
-    return checkFileExistsOnWeb(path)
+    return await checkFileExistsOnWeb(path)
   } else {
 
     if (typeof window !== 'undefined' && typeof window.document !== 'undefined') {

--- a/src/common.ts
+++ b/src/common.ts
@@ -83,7 +83,7 @@ export async function checkFileExistsOnWeb(url: string): Promise<boolean> {
 
 export async function checkFileExists(path: string): Promise<boolean> {
   if (isValidUrl(path)) {
-    return await checkFileExistsOnWeb(path)
+    return checkFileExistsOnWeb(path)
   } else {
 
     if (typeof process === 'undefined' && typeof window !== 'undefined') {

--- a/src/rln.ts
+++ b/src/rln.ts
@@ -227,13 +227,13 @@ export class RLN implements IRLN {
 
     if (typeof args.wasmFilePath === 'string' && !await checkFileExists(args.wasmFilePath)) {
       throw new Error(
-        'the file does not exist at the path for `wasmFilePath`'
+        'the file does not exist at the path for `wasmFilePath`',
       )
     }
 
     if (typeof args.finalZkeyPath === 'string' && !await checkFileExists(args.finalZkeyPath)) {
       throw new Error(
-        'the file does not exist at the path for `finalZkeyPath`'
+        'the file does not exist at the path for `finalZkeyPath`',
       )
     }
 

--- a/src/rln.ts
+++ b/src/rln.ts
@@ -227,13 +227,13 @@ export class RLN implements IRLN {
 
     if (typeof args.wasmFilePath === 'string' && !await checkFileExists(args.wasmFilePath)) {
       throw new Error(
-        'the file does not exist at the path for `wasmFilePath`',
+        `the file does not exist at the path for \`wasmFilePath\`: wasmFilePath=${args.wasmFilePath}`,
       )
     }
 
     if (typeof args.finalZkeyPath === 'string' && !await checkFileExists(args.finalZkeyPath)) {
       throw new Error(
-        'the file does not exist at the path for `finalZkeyPath`',
+        `the file does not exist at the path for \`finalZkeyPath\`: finalZkeyPath=${args.finalZkeyPath}`,
       )
     }
 

--- a/src/rln.ts
+++ b/src/rln.ts
@@ -1,6 +1,6 @@
 import { Identity } from '@semaphore-protocol/identity'
 import { VerificationKey } from './types'
-import { DEFAULT_MERKLE_TREE_DEPTH, calculateIdentitySecret, calculateSignalHash } from './common'
+import { DEFAULT_MERKLE_TREE_DEPTH, calculateIdentitySecret, calculateSignalHash, checkFileExists } from './common'
 import { IRLNRegistry, ContractRLNRegistry } from './registry'
 import { MemoryCache, EvaluatedProof, ICache, Status } from './cache'
 import { IMessageIDCounter, MemoryMessageIDCounter } from './message-id-counter'
@@ -224,6 +224,19 @@ export class RLN implements IRLN {
     let wasmFilePath: string | Uint8Array | undefined
     let finalZkeyPath: string | Uint8Array | undefined
     let verificationKey: VerificationKey | undefined
+
+    if (typeof args.wasmFilePath === 'string' && !await checkFileExists(args.wasmFilePath)) {
+      throw new Error(
+        'the file does not exist at the path for `wasmFilePath`'
+      )
+    }
+
+    if (typeof args.finalZkeyPath === 'string' && !await checkFileExists(args.finalZkeyPath)) {
+      throw new Error(
+        'the file does not exist at the path for `finalZkeyPath`'
+      )
+    }
+
     // If `args.wasmFilePath`, `args.finalZkeyPath`, and `args.verificationKey` are not given, see if we have defaults that can be used
     if (args.wasmFilePath === undefined && args.finalZkeyPath === undefined && args.verificationKey === undefined) {
       const defaultParams = await getDefaultRLNParams(treeDepth)

--- a/src/rln.ts
+++ b/src/rln.ts
@@ -359,6 +359,19 @@ export class RLN implements IRLN {
     // If all params are not given, use the default
     let withdrawWasmFilePath: string | Uint8Array | undefined
     let withdrawFinalZkeyPath: string | Uint8Array | undefined
+
+    if (typeof args.withdrawWasmFilePath === 'string' && !await checkFileExists(args.withdrawWasmFilePath)) {
+      throw new Error(
+        `the file does not exist at the path for \`withdrawWasmFilePath\`: withdrawWasmFilePath=${args.withdrawWasmFilePath}`,
+      )
+    }
+
+    if (typeof args.withdrawFinalZkeyPath === 'string' && !await checkFileExists(args.withdrawFinalZkeyPath)) {
+      throw new Error(
+        `the file does not exist at the path for \`withdrawFinalZkeyPath\`: withdrawFinalZkeyPath=${args.withdrawFinalZkeyPath}`,
+      )
+    }
+
     // If `args.withdrawWasmFilePath`, `args.finalZkeyPath`, see if we have defaults that can be used
     if (args.withdrawWasmFilePath === undefined && args.withdrawFinalZkeyPath === undefined) {
       const defaultParams = await getDefaultWithdrawParams()

--- a/tests/rln.test.ts
+++ b/tests/rln.test.ts
@@ -126,7 +126,7 @@ describe("RLN", function () {
         });
 
         test("should fail when finalZkeyPath doesn't exist on local", async function () {
-            const wasmFilePath = "./packages.json"
+            const wasmFilePath = "./package.json"
             const finalZkeyPath = "./404"
             await expect(async () => {
                 await RLN.createWithContractRegistry({

--- a/tests/rln.test.ts
+++ b/tests/rln.test.ts
@@ -74,6 +74,74 @@ describe("RLN", function () {
             );
         });
 
+        test("should fail when wasmFilePath doesn't exist on the web", async function () {
+            const wasmFilePath = "https://rln-trusted-setup-ceremony-pse-p0tion-production.s3.eu-central-1.amazonaws.com/404"
+            const finalZkeyPath = "https://rln-trusted-setup-ceremony-pse-p0tion-production.s3.eu-central-1.amazonaws.com/404"
+            await expect(async () => {
+                await RLN.createWithContractRegistry({
+                    rlnIdentifier: rlnIdentifierA,
+                    treeDepth: treeDepthWithoutDefaultParams,
+                    provider: fakeProvider,
+                    contractAddress: fakeContractAddress,
+                    wasmFilePath: wasmFilePath,
+                    finalZkeyPath: finalZkeyPath
+                });
+            }).rejects.toThrow(
+                `the file does not exist at the path for \`wasmFilePath\`: wasmFilePath=${wasmFilePath}`
+            );
+        });
+
+        test("should fail when finalZkeyPath doesn't exist on the web", async function () {
+            const wasmFilePath = "https://rln-trusted-setup-ceremony-pse-p0tion-production.s3.eu-central-1.amazonaws.com/circuits/rln-20/RLN-20.wasm"
+            const finalZkeyPath = "https://rln-trusted-setup-ceremony-pse-p0tion-production.s3.eu-central-1.amazonaws.com/404"
+            await expect(async () => {
+                await RLN.createWithContractRegistry({
+                    rlnIdentifier: rlnIdentifierA,
+                    treeDepth: treeDepthWithoutDefaultParams,
+                    provider: fakeProvider,
+                    contractAddress: fakeContractAddress,
+                    wasmFilePath: wasmFilePath,
+                    finalZkeyPath: finalZkeyPath
+                });
+            }).rejects.toThrow(
+                `the file does not exist at the path for \`finalZkeyPath\`: finalZkeyPath=${finalZkeyPath}`
+            );
+        });
+
+        test("should fail when wasmFilePath doesn't exist on local", async function () {
+            const wasmFilePath = "./404"
+            const finalZkeyPath = "./404"
+            await expect(async () => {
+                await RLN.createWithContractRegistry({
+                    rlnIdentifier: rlnIdentifierA,
+                    treeDepth: treeDepthWithoutDefaultParams,
+                    provider: fakeProvider,
+                    contractAddress: fakeContractAddress,
+                    wasmFilePath: wasmFilePath,
+                    finalZkeyPath: finalZkeyPath
+                });
+            }).rejects.toThrow(
+                `the file does not exist at the path for \`wasmFilePath\`: wasmFilePath=${wasmFilePath}`
+            );
+        });
+
+        test("should fail when finalZkeyPath doesn't exist on local", async function () {
+            const wasmFilePath = "./packages.json"
+            const finalZkeyPath = "./404"
+            await expect(async () => {
+                await RLN.createWithContractRegistry({
+                    rlnIdentifier: rlnIdentifierA,
+                    treeDepth: treeDepthWithoutDefaultParams,
+                    provider: fakeProvider,
+                    contractAddress: fakeContractAddress,
+                    wasmFilePath: wasmFilePath,
+                    finalZkeyPath: finalZkeyPath
+                });
+            }).rejects.toThrow(
+                `the file does not exist at the path for \`finalZkeyPath\`: finalZkeyPath=${finalZkeyPath}`
+            );
+        });
+
         test("should fail to prove if no proving params is given as constructor arguments", async function () {
             const rln = await RLN.createWithContractRegistry({
                 rlnIdentifier: rlnIdentifierA,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "target": "ES5",
-    "module": "ES6",
+    "module": "ES2020",
     "moduleResolution": "node",
     "allowJs": true,
     "allowSyntheticDefaultImports": true,


### PR DESCRIPTION
fix: https://github.com/Rate-Limiting-Nullifier/rlnjs/issues/49

description:
- I will check if there are files at wasmFilePath and finalZkeyPath. 
- The path can be either a local file path or a URL. 
- There are two environments at runtime: the browser environment and the Node.js environment. During the browser environment, you cannot access the path to a local file. 
- I am using the window and process variables to determine if it's a browser environment.